### PR TITLE
Factor out a separate type for the SpecifiedLength

### DIFF
--- a/math-core/src/lib.rs
+++ b/math-core/src/lib.rs
@@ -265,6 +265,8 @@ mod tests {
             ),
             ("genfrac_0.4pt", r"\genfrac(]{0.4pt}{2}{a+b}{c+d}"),
             ("genfrac_1px", r"\genfrac(]{1px}{2}{a+b}{c+d}"),
+            ("genfrac_0.4ex", r"\genfrac(]{0.4ex}{2}{a+b}{c+d}"),
+            ("genfrac_4em", r"\genfrac(]{4em}{2}{a+b}{c+d}"),
             ("not_subset", r"\not\subset"),
             ("not_less_than", r"\not\lt"),
             ("not_less_than_symbol", r"\not< x"),

--- a/math-core/src/parse.rs
+++ b/math-core/src/parse.rs
@@ -262,7 +262,7 @@ where
                 let num = self.parse_next(true)?;
                 let den = self.parse_next(true)?;
                 if matches!(cur_token, Token::Binom(_)) {
-                    let lt = Some(AbsoluteLength::from_twip(0));
+                    let lt = Some(AbsoluteLength::from_twip(0).into());
                     Node::Fenced {
                         open: symbol::LEFT_PARENTHESIS,
                         close: symbol::RIGHT_PARENTHESIS,

--- a/math-core/src/parse.rs
+++ b/math-core/src/parse.rs
@@ -7,7 +7,7 @@ use mathml_renderer::{
         Align, FracAttr, MathSpacing, MathVariant, OpAttr, RowAttr, StretchMode, Style,
         TextTransform,
     },
-    length::Length,
+    length::AbsoluteLength,
     symbol,
 };
 
@@ -262,7 +262,7 @@ where
                 let num = self.parse_next(true)?;
                 let den = self.parse_next(true)?;
                 if matches!(cur_token, Token::Binom(_)) {
-                    let lt = Some(Length::from_twip(0));
+                    let lt = Some(AbsoluteLength::from_twip(0));
                     Node::Fenced {
                         open: symbol::LEFT_PARENTHESIS,
                         close: symbol::RIGHT_PARENTHESIS,

--- a/math-core/src/snapshots/math_core__tests__genfrac_0.4ex.snap
+++ b/math-core/src/snapshots/math_core__tests__genfrac_0.4ex.snap
@@ -1,0 +1,22 @@
+---
+source: math-core/src/lib.rs
+expression: "\\genfrac(]{0.4ex}{2}{a+b}{c+d}"
+---
+<math>
+    <mrow displaystyle="false" scriptlevel="1">
+        <mo>(</mo>
+        <mfrac linethickness="0.4ex">
+            <mrow>
+                <mi>a</mi>
+                <mo>+</mo>
+                <mi>b</mi>
+            </mrow>
+            <mrow>
+                <mi>c</mi>
+                <mo>+</mo>
+                <mi>d</mi>
+            </mrow>
+        </mfrac>
+        <mo>]</mo>
+    </mrow>
+</math>

--- a/math-core/src/snapshots/math_core__tests__genfrac_4em.snap
+++ b/math-core/src/snapshots/math_core__tests__genfrac_4em.snap
@@ -1,0 +1,22 @@
+---
+source: math-core/src/lib.rs
+expression: "\\genfrac(]{4em}{2}{a+b}{c+d}"
+---
+<math>
+    <mrow displaystyle="false" scriptlevel="1">
+        <mo>(</mo>
+        <mfrac linethickness="4em">
+            <mrow>
+                <mi>a</mi>
+                <mo>+</mo>
+                <mi>b</mi>
+            </mrow>
+            <mrow>
+                <mi>c</mi>
+                <mo>+</mo>
+                <mi>d</mi>
+            </mrow>
+        </mfrac>
+        <mo>]</mo>
+    </mrow>
+</math>

--- a/math-core/src/specifications.rs
+++ b/math-core/src/specifications.rs
@@ -2,11 +2,11 @@
 
 use std::num::NonZeroU32;
 
-use mathml_renderer::length::{Length, PT_IN_LEN, PX_IN_LEN};
+use mathml_renderer::length::{AbsoluteLength, PT_IN_LEN, PX_IN_LEN};
 
 const TEN: NonZeroU32 = NonZeroU32::new(10).unwrap();
 
-pub(crate) fn parse_length_specification(s: &str) -> Result<Length, ()> {
+pub(crate) fn parse_length_specification(s: &str) -> Result<AbsoluteLength, ()> {
     let len = s.len();
     // We need at least 2 characters to have a unit.
     let Some(unit_offset) = len.checked_sub(2) else {
@@ -43,7 +43,7 @@ pub(crate) fn parse_length_specification(s: &str) -> Result<Length, ()> {
         acc += u32::from(digit - b'0');
         div = div.saturating_mul(TEN);
     }
-    Ok(Length::from_value((acc * conv.get() / div) as i32))
+    Ok(AbsoluteLength::from_value((acc * conv.get() / div) as i32))
 }
 
 #[cfg(test)]

--- a/mathml_renderer/src/ast.rs
+++ b/mathml_renderer/src/ast.rs
@@ -7,7 +7,7 @@ use crate::attribute::{
     Align, FracAttr, MathSpacing, MathVariant, OpAttr, RowAttr, Size, StretchMode, Stretchy, Style,
 };
 use crate::itoa::append_u8_as_hex;
-use crate::length::AbsoluteLength;
+use crate::length::SpecifiedLength;
 use crate::symbol::{Op, ParenOp};
 
 /// AST node
@@ -65,7 +65,7 @@ pub enum Node<'arena> {
         /// Denominator
         den: &'arena Node<'arena>,
         /// Line thickness
-        lt: Option<AbsoluteLength>,
+        lt: Option<SpecifiedLength>,
         attr: Option<FracAttr>,
     },
     Row {
@@ -576,7 +576,7 @@ mod tests {
     use crate::attribute::{
         FracAttr, MathSpacing, MathVariant, OpAttr, RowAttr, Style, TextTransform,
     };
-    use crate::length::AbsoluteLength;
+    use crate::length::{AbsoluteLength, FontRelativeLength};
     use crate::symbol;
 
     pub fn render<'a, 'b>(node: &'a Node<'b>) -> String
@@ -810,7 +810,7 @@ mod tests {
             render(&Node::Frac {
                 num,
                 den,
-                lt: Some(AbsoluteLength::from_pt(-1)),
+                lt: Some(AbsoluteLength::from_pt(-1).into()),
                 attr: None,
             }),
             "<mfrac linethickness=\"-1pt\"><mn>1</mn><mn>2</mn></mfrac>"
@@ -819,7 +819,25 @@ mod tests {
             render(&Node::Frac {
                 num,
                 den,
-                lt: Some(AbsoluteLength::from_pt(2)),
+                lt: Some(FontRelativeLength::from_em(1).into()),
+                attr: None,
+            }),
+            "<mfrac linethickness=\"1em\"><mn>1</mn><mn>2</mn></mfrac>"
+        );
+        assert_eq!(
+            render(&Node::Frac {
+                num,
+                den,
+                lt: Some(FontRelativeLength::from_ex(-1).into()),
+                attr: None,
+            }),
+            "<mfrac linethickness=\"-1ex\"><mn>1</mn><mn>2</mn></mfrac>"
+        );
+        assert_eq!(
+            render(&Node::Frac {
+                num,
+                den,
+                lt: Some(AbsoluteLength::from_pt(2).into()),
                 attr: None,
             }),
             "<mfrac linethickness=\"2pt\"><mn>1</mn><mn>2</mn></mfrac>"
@@ -829,7 +847,7 @@ mod tests {
                 num,
                 den,
                 // 8/20 = 4/10
-                lt: Some(AbsoluteLength::from_twip(-8)),
+                lt: Some(AbsoluteLength::from_twip(-8).into()),
                 attr: None,
             }),
             "<mfrac linethickness=\"-0.4pt\"><mn>1</mn><mn>2</mn></mfrac>"
@@ -847,7 +865,7 @@ mod tests {
             render(&Node::Frac {
                 num,
                 den,
-                lt: Some(AbsoluteLength::from_pt(0)),
+                lt: Some(AbsoluteLength::from_pt(0).into()),
                 attr: Some(FracAttr::DisplayStyleTrue),
             }),
             "<mfrac linethickness=\"0\" displaystyle=\"true\"><mn>1</mn><mn>2</mn></mfrac>"

--- a/mathml_renderer/src/ast.rs
+++ b/mathml_renderer/src/ast.rs
@@ -7,7 +7,7 @@ use crate::attribute::{
     Align, FracAttr, MathSpacing, MathVariant, OpAttr, RowAttr, Size, StretchMode, Stretchy, Style,
 };
 use crate::itoa::append_u8_as_hex;
-use crate::length::Length;
+use crate::length::AbsoluteLength;
 use crate::symbol::{Op, ParenOp};
 
 /// AST node
@@ -65,7 +65,7 @@ pub enum Node<'arena> {
         /// Denominator
         den: &'arena Node<'arena>,
         /// Line thickness
-        lt: Option<Length>,
+        lt: Option<AbsoluteLength>,
         attr: Option<FracAttr>,
     },
     Row {
@@ -576,7 +576,7 @@ mod tests {
     use crate::attribute::{
         FracAttr, MathSpacing, MathVariant, OpAttr, RowAttr, Style, TextTransform,
     };
-    use crate::length::Length;
+    use crate::length::AbsoluteLength;
     use crate::symbol;
 
     pub fn render<'a, 'b>(node: &'a Node<'b>) -> String
@@ -810,7 +810,7 @@ mod tests {
             render(&Node::Frac {
                 num,
                 den,
-                lt: Some(Length::from_pt(-1)),
+                lt: Some(AbsoluteLength::from_pt(-1)),
                 attr: None,
             }),
             "<mfrac linethickness=\"-1pt\"><mn>1</mn><mn>2</mn></mfrac>"
@@ -819,7 +819,7 @@ mod tests {
             render(&Node::Frac {
                 num,
                 den,
-                lt: Some(Length::from_pt(2)),
+                lt: Some(AbsoluteLength::from_pt(2)),
                 attr: None,
             }),
             "<mfrac linethickness=\"2pt\"><mn>1</mn><mn>2</mn></mfrac>"
@@ -829,7 +829,7 @@ mod tests {
                 num,
                 den,
                 // 8/20 = 4/10
-                lt: Some(Length::from_twip(-8)),
+                lt: Some(AbsoluteLength::from_twip(-8)),
                 attr: None,
             }),
             "<mfrac linethickness=\"-0.4pt\"><mn>1</mn><mn>2</mn></mfrac>"
@@ -847,7 +847,7 @@ mod tests {
             render(&Node::Frac {
                 num,
                 den,
-                lt: Some(Length::from_pt(0)),
+                lt: Some(AbsoluteLength::from_pt(0)),
                 attr: Some(FracAttr::DisplayStyleTrue),
             }),
             "<mfrac linethickness=\"0\" displaystyle=\"true\"><mn>1</mn><mn>2</mn></mfrac>"

--- a/mathml_renderer/src/length.rs
+++ b/mathml_renderer/src/length.rs
@@ -25,29 +25,29 @@ pub const PX_IN_LEN: NonZeroU32 = NonZeroU32::new(480).unwrap();
 /// An absolute length.
 /// See [the module][crate::length] for more information.
 #[derive(Debug, Clone, Copy)]
-pub struct Length(NonZeroI32);
+pub struct AbsoluteLength(NonZeroI32);
 
-impl Length {
-    pub fn from_pt(pt: i32) -> Length {
-        Length::from_value(pt * (PT_IN_LEN.get() as i32))
+impl AbsoluteLength {
+    pub fn from_pt(pt: i32) -> AbsoluteLength {
+        AbsoluteLength::from_value(pt * (PT_IN_LEN.get() as i32))
     }
 
-    pub fn from_twip(twip: i32) -> Length {
-        Length::from_value(twip * (PT_IN_LEN.get() as i32 / 10) / 2)
+    pub fn from_twip(twip: i32) -> AbsoluteLength {
+        AbsoluteLength::from_value(twip * (PT_IN_LEN.get() as i32 / 10) / 2)
     }
 
-    pub fn from_px(px: i32) -> Length {
-        Length::from_value(px * (PX_IN_LEN.get() as i32))
+    pub fn from_px(px: i32) -> AbsoluteLength {
+        AbsoluteLength::from_value(px * (PX_IN_LEN.get() as i32))
     }
 
-    pub fn from_value(value: i32) -> Length {
+    pub fn from_value(value: i32) -> AbsoluteLength {
         // The problem that we are trying to solve here is that we want a niche in `Length`
         // but we also want to be able to represent 0, so we cannot just use `NonZeroI32` as is.
         // What we're doing here instead is adding `i32::MIN` to the plain value, such that
         // `i32::MIN` maps to 0, where the niche is. So, we can no longer represent `i32::MIN`,
         // but that's fine. We map the original value of `i32::MIN` to 1, which corresponds to
         // `i32::MIN + 1` in the original value space.
-        Length(
+        AbsoluteLength(
             NonZeroI32::new(value.wrapping_add(i32::MIN))
                 .unwrap_or(const { NonZeroI32::new(1).unwrap() }),
         )
@@ -107,7 +107,7 @@ fn write_impl(value: i32, output: &mut String, conv: NonZeroU32, unit: &str) {
 }
 
 #[cfg(feature = "serde")]
-impl Serialize for Length {
+impl Serialize for AbsoluteLength {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_i32(self.value())
     }
@@ -120,34 +120,34 @@ mod tests {
     #[test]
     fn write() {
         let mut output = String::new();
-        Length::from_pt(0).push_to_string(&mut output);
+        AbsoluteLength::from_pt(0).push_to_string(&mut output);
         assert_eq!(&output, "0");
         output.clear();
-        Length::from_pt(1).push_to_string(&mut output);
+        AbsoluteLength::from_pt(1).push_to_string(&mut output);
         assert_eq!(&output, "1pt");
         output.clear();
-        Length::from_pt(10).push_to_string(&mut output);
+        AbsoluteLength::from_pt(10).push_to_string(&mut output);
         assert_eq!(&output, "10pt");
         output.clear();
-        Length::from_pt(5965232).push_to_string(&mut output);
+        AbsoluteLength::from_pt(5965232).push_to_string(&mut output);
         assert_eq!(&output, "5965232pt");
         output.clear();
-        Length::from_pt(-5965232).push_to_string(&mut output);
+        AbsoluteLength::from_pt(-5965232).push_to_string(&mut output);
         assert_eq!(&output, "-5965232pt");
         output.clear();
-        Length::from_px(0).push_to_string(&mut output);
+        AbsoluteLength::from_px(0).push_to_string(&mut output);
         assert_eq!(&output, "0");
         output.clear();
-        Length::from_px(1).push_to_string(&mut output);
+        AbsoluteLength::from_px(1).push_to_string(&mut output);
         assert_eq!(&output, "1px");
         output.clear();
-        Length::from_px(10).push_to_string(&mut output);
+        AbsoluteLength::from_px(10).push_to_string(&mut output);
         assert_eq!(&output, "10px");
         output.clear();
-        Length::from_px(4473923).push_to_string(&mut output);
+        AbsoluteLength::from_px(4473923).push_to_string(&mut output);
         assert_eq!(&output, "4473923px");
         output.clear();
-        Length::from_px(-4473923).push_to_string(&mut output);
+        AbsoluteLength::from_px(-4473923).push_to_string(&mut output);
         assert_eq!(&output, "-4473923px");
     }
 }

--- a/mathml_renderer/src/length.rs
+++ b/mathml_renderer/src/length.rs
@@ -1,15 +1,4 @@
-//! A length, stored in $\frac{1}{360}$ of an imperial point.
-//!
-//! This is also equal to $\frac{1}{480}$ of a CSS pixel, as demonstrated by
-//! the following dimensional analysis and [CSS Values and Units 4]:
-//!
-//! $$`
-//! 1 len \times \frac{360 point}{1 nip} \times \frac{1 inch}{72 point}
-//! \times \frac{96 pixel}{1 inch} = 480 pixel
-//! `$$
-//!
-//! [CSS values and units 4]:
-//!     https://www.w3.org/TR/css-values-4/#absolute-lengths
+//! Lengths, both absolute and relative to font size.
 
 use std::mem::MaybeUninit;
 use std::num::{NonZeroI32, NonZeroU32};
@@ -22,32 +11,39 @@ use crate::itoa::fmt_u32;
 pub const PT_IN_LEN: NonZeroU32 = NonZeroU32::new(360).unwrap();
 pub const PX_IN_LEN: NonZeroU32 = NonZeroU32::new(480).unwrap();
 
-/// An absolute length.
-/// See [the module][crate::length] for more information.
+pub const FONT_RELATIVE_CONV: NonZeroU32 = NonZeroU32::new(60).unwrap();
+
+/// A specified length, either [`AbsoluteLength`] or [`FontRelativeLength`],
+/// but with the bounds shaved off the top (it has about 30 significant bits).
 #[derive(Debug, Clone, Copy)]
-pub struct AbsoluteLength(NonZeroI32);
+pub struct SpecifiedLength(NonZeroI32);
 
-impl AbsoluteLength {
-    pub fn from_pt(pt: i32) -> AbsoluteLength {
-        AbsoluteLength::from_value(pt * (PT_IN_LEN.get() as i32))
+impl SpecifiedLength {
+    /// Convert from an absolute length.
+    /// This may truncate the value if it's very high or low.
+    pub fn from_absolute_length(len: AbsoluteLength) -> SpecifiedLength {
+        let value = len.0 << 1;
+        SpecifiedLength::from_value(value)
     }
 
-    pub fn from_twip(twip: i32) -> AbsoluteLength {
-        AbsoluteLength::from_value(twip * (PT_IN_LEN.get() as i32 / 10) / 2)
+    /// Convert from a font-relative length.
+    pub fn from_font_relative_length(len: FontRelativeLength) -> SpecifiedLength {
+        let value = len.value << 2;
+        let flag = match len.unit {
+            FontRelativeUnit::Em => 0x1,
+            FontRelativeUnit::Ex => 0x3,
+        };
+        SpecifiedLength::from_value(value | flag)
     }
 
-    pub fn from_px(px: i32) -> AbsoluteLength {
-        AbsoluteLength::from_value(px * (PX_IN_LEN.get() as i32))
-    }
-
-    pub fn from_value(value: i32) -> AbsoluteLength {
-        // The problem that we are trying to solve here is that we want a niche in `Length`
+    pub fn from_value(value: i32) -> SpecifiedLength {
+        // The problem that we are trying to solve here is that we want a niche in `SpecifiedLength`
         // but we also want to be able to represent 0, so we cannot just use `NonZeroI32` as is.
         // What we're doing here instead is adding `i32::MIN` to the plain value, such that
         // `i32::MIN` maps to 0, where the niche is. So, we can no longer represent `i32::MIN`,
         // but that's fine. We map the original value of `i32::MIN` to 1, which corresponds to
         // `i32::MIN + 1` in the original value space.
-        AbsoluteLength(
+        SpecifiedLength(
             NonZeroI32::new(value.wrapping_add(i32::MIN))
                 .unwrap_or(const { NonZeroI32::new(1).unwrap() }),
         )
@@ -57,18 +53,91 @@ impl AbsoluteLength {
         i32::from(self.0).wrapping_sub(i32::MIN)
     }
 
+    pub fn kind(self) -> LengthKind {
+        let value = self.value() >> 2;
+        match self.value() & 0x3 {
+            0x1 => LengthKind::FontRelativeLength(FontRelativeLength {
+                value,
+                unit: FontRelativeUnit::Em,
+            }),
+            0x3 => LengthKind::FontRelativeLength(FontRelativeLength {
+                value,
+                unit: FontRelativeUnit::Ex,
+            }),
+            _ => LengthKind::AbsoluteLength(AbsoluteLength(self.value() >> 1)),
+        }
+    }
+
+    pub fn push_to_string(&self, output: &mut String) {
+        match self.kind() {
+            LengthKind::AbsoluteLength(len) => len.push_to_string(output),
+            LengthKind::FontRelativeLength(len) => len.push_to_string(output),
+        }
+    }
+}
+
+impl From<AbsoluteLength> for SpecifiedLength {
+    #[inline]
+    fn from(a: AbsoluteLength) -> SpecifiedLength {
+        SpecifiedLength::from_absolute_length(a)
+    }
+}
+
+impl From<FontRelativeLength> for SpecifiedLength {
+    #[inline]
+    fn from(a: FontRelativeLength) -> SpecifiedLength {
+        SpecifiedLength::from_font_relative_length(a)
+    }
+}
+
+/// An internal wrapper type, so that we can use pattern matching
+/// over both kinds of length.
+#[derive(Debug, Clone, Copy)]
+pub enum LengthKind {
+    AbsoluteLength(AbsoluteLength),
+    FontRelativeLength(FontRelativeLength),
+}
+
+/// A length, stored in $\frac{1}{360}$ of an imperial point.
+///
+/// This is also equal to $\frac{1}{480}$ of a CSS pixel, as demonstrated by
+/// the following dimensional analysis and [CSS Values and Units 4]:
+///
+/// $$`
+/// 1 len \times \frac{360 point}{1 nip} \times \frac{1 inch}{72 point}
+/// \times \frac{96 pixel}{1 inch} = 480 pixel
+/// `$$
+///
+/// [CSS values and units 4]:
+///     https://www.w3.org/TR/css-values-4/#absolute-lengths
+#[derive(Debug, Clone, Copy)]
+pub struct AbsoluteLength(pub i32);
+
+impl AbsoluteLength {
+    pub fn from_pt(pt: i32) -> AbsoluteLength {
+        AbsoluteLength(pt * (PT_IN_LEN.get() as i32))
+    }
+
+    pub fn from_twip(twip: i32) -> AbsoluteLength {
+        AbsoluteLength(twip * (PT_IN_LEN.get() as i32 / 10) / 2)
+    }
+
+    pub fn from_px(px: i32) -> AbsoluteLength {
+        AbsoluteLength(px * (PX_IN_LEN.get() as i32))
+    }
+
     pub fn display_px(self, output: &mut String) {
-        let value = self.value();
+        let value = self.0;
         write_impl(value, output, PX_IN_LEN, "px")
     }
 
     pub fn display_pt(self, output: &mut String) {
-        let value = self.value();
+        let value = self.0;
         write_impl(value, output, PT_IN_LEN, "pt")
     }
 
     pub fn push_to_string(&self, output: &mut String) {
-        let value = self.value();
+        let value = self.0;
         if value == 0 {
             output.push('0');
         } else {
@@ -84,6 +153,51 @@ impl AbsoluteLength {
             write_impl(value, output, conv, unit)
         }
     }
+}
+
+/// A font-relative length, stored with an explicit tag and the type of
+/// font multiplied by 60.
+#[derive(Debug, Clone, Copy)]
+pub struct FontRelativeLength {
+    pub unit: FontRelativeUnit,
+    pub value: i32,
+}
+
+impl FontRelativeLength {
+    pub fn from_ex(ex: i32) -> FontRelativeLength {
+        FontRelativeLength {
+            value: ex * 60,
+            unit: FontRelativeUnit::Ex,
+        }
+    }
+    pub fn from_em(em: i32) -> FontRelativeLength {
+        FontRelativeLength {
+            value: em * 60,
+            unit: FontRelativeUnit::Em,
+        }
+    }
+    pub fn push_to_string(&self, output: &mut String) {
+        let value = self.value;
+        if value == 0 {
+            output.push('0');
+        } else {
+            write_impl(
+                value,
+                output,
+                FONT_RELATIVE_CONV,
+                match self.unit {
+                    FontRelativeUnit::Em => "em",
+                    FontRelativeUnit::Ex => "ex",
+                },
+            )
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FontRelativeUnit {
+    Em = 0x1,
+    Ex = 0x3,
 }
 
 fn write_impl(value: i32, output: &mut String, conv: NonZeroU32, unit: &str) {
@@ -107,9 +221,37 @@ fn write_impl(value: i32, output: &mut String, conv: NonZeroU32, unit: &str) {
 }
 
 #[cfg(feature = "serde")]
+impl Serialize for SpecifiedLength {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self.kind() {
+            LengthKind::AbsoluteLength(len) => len.serialize(serializer),
+            LengthKind::FontRelativeLength(len) => len.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
 impl Serialize for AbsoluteLength {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_i32(self.value())
+        serializer.serialize_i32(self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for FontRelativeLength {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        (self.value, self.unit).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for FontRelativeUnit {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        (match *self {
+            FontRelativeUnit::Em => "em",
+            FontRelativeUnit::Ex => "ex",
+        })
+        .serialize(serializer)
     }
 }
 
@@ -149,5 +291,34 @@ mod tests {
         output.clear();
         AbsoluteLength::from_px(-4473923).push_to_string(&mut output);
         assert_eq!(&output, "-4473923px");
+    }
+
+    #[test]
+    fn write_relative() {
+        let mut output = String::new();
+        FontRelativeLength::from_em(0).push_to_string(&mut output);
+        assert_eq!(&output, "0");
+        output.clear();
+        FontRelativeLength::from_ex(0).push_to_string(&mut output);
+        assert_eq!(&output, "0");
+        output.clear();
+        FontRelativeLength::from_em(1).push_to_string(&mut output);
+        assert_eq!(&output, "1em");
+        output.clear();
+        FontRelativeLength::from_ex(1).push_to_string(&mut output);
+        assert_eq!(&output, "1ex");
+        output.clear();
+        FontRelativeLength::from_em(546).push_to_string(&mut output);
+        assert_eq!(&output, "546em");
+        output.clear();
+        FontRelativeLength::from_ex(546).push_to_string(&mut output);
+        assert_eq!(&output, "546ex");
+        output.clear();
+        FontRelativeLength::from_em(-546).push_to_string(&mut output);
+        assert_eq!(&output, "-546em");
+        output.clear();
+        FontRelativeLength::from_ex(-546).push_to_string(&mut output);
+        assert_eq!(&output, "-546ex");
+        output.clear();
     }
 }


### PR DESCRIPTION
This sets things up so that there's a data type with hand-bitpacking to distinguish:

- absolute lengths, which are all normalized to the same unit
- font-relative lengths, which can't be and need another bit to distinguish ex and em units

This is a good data type to store user-specified lengths in, but it's not appropriate for layout calculations (we don't know how big an `ex` is relative to a `pt`, so `1ex + 1pt` has to be stored just like that and emitted as a `calc()` expression).