### PR TITLE
Add initial support for parsing custom commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
 name = "math-core-wasm"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "lol_alloc",
  "math-core",
  "wasm-bindgen",

--- a/math-core-cli/src/main.rs
+++ b/math-core-cli/src/main.rs
@@ -106,7 +106,8 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    let mut converter = Converter::new(Config::default());
+    let mut converter =
+        Converter::new(&Config::default()).unwrap_or_else(|err| exit_latex_error(err, None));
     if let Some(ref fpath) = args.file {
         let inline_delim: (&str, &str) = if let Some(ref open) = args.inline_open {
             (open, &args.inline_close.unwrap())
@@ -288,7 +289,7 @@ A rigid body which has the figure of a sphere when measured in the moving system
 condition — when considered from the stationary system, the figure of a rotational ellipsoid with semi-axes
 $$R {\sqrt{1-{\frac {v^{2}}{c^{2}}}}}, \ R, \ R .$$
 "#;
-        let mut converter = math_core::Converter::new(math_core::Config::default());
+        let mut converter = math_core::Converter::new(&math_core::Config::default()).unwrap();
         let mut replacer = crate::Replacer::new(("$", "$"), ("$$", "$$"), false, false);
         let mathml = crate::replace(&mut replacer, text, &mut converter).unwrap();
         println!("{}", mathml);

--- a/math-core-cli/src/main.rs
+++ b/math-core-cli/src/main.rs
@@ -189,12 +189,12 @@ fn convert_and_exit(args: &Args, latex: &str, converter: &mut Converter) {
 fn replace<'source, 'buf>(
     replacer: &'buf mut Replacer,
     input: &'source str,
-    converter: &mut Converter,
+    converter: &'buf mut Converter,
 ) -> Result<String, ConversionError<'source, 'buf>>
 where
     'source: 'buf,
 {
-    replacer.replace(input, |buf, latex, display| {
+    replacer.replace(input, converter, |converter, buf, latex, display| {
         let result = converter.latex_to_mathml(latex, display)?;
         buf.push_str(result.as_str());
         Ok(())

--- a/math-core-cli/src/replace.rs
+++ b/math-core-cli/src/replace.rs
@@ -70,9 +70,9 @@ fn line_and_col(loc: usize, input: &str) -> (usize, usize) {
     (line, col)
 }
 
-pub struct Replacer<'config> {
-    opening_finders: (Finder<'config>, Finder<'config>),
-    closing_finders: (Finder<'config>, Finder<'config>),
+pub struct Replacer<'args> {
+    opening_finders: (Finder<'args>, Finder<'args>),
+    closing_finders: (Finder<'args>, Finder<'args>),
     opening_lengths: (usize, usize),
     closing_lengths: (usize, usize),
     closing_identical: bool,

--- a/math-core-python/src/lib.rs
+++ b/math-core-python/src/lib.rs
@@ -11,7 +11,7 @@ create_exception!(_math_core_rust, LatexError, PyException);
 
 #[pyclass]
 struct Converter {
-    inner: Mutex<math_core::Converter>,
+    inner: Mutex<Box<math_core::Converter>>,
 }
 
 #[pymethods]

--- a/math-core-python/src/lib.rs
+++ b/math-core-python/src/lib.rs
@@ -11,7 +11,7 @@ create_exception!(_math_core_rust, LatexError, PyException);
 
 #[pyclass]
 struct Converter {
-    inner: Mutex<Box<math_core::Converter>>,
+    inner: Mutex<math_core::Converter>,
 }
 
 #[pymethods]
@@ -31,7 +31,7 @@ impl Converter {
             Default::default()
         };
         Ok(Converter {
-            inner: Mutex::new(Box::new(math_core::Converter::new(config))),
+            inner: Mutex::new(Box::new(math_core::Converter::new(&config).unwrap())),
         })
     }
 

--- a/math-core-wasm/Cargo.toml
+++ b/math-core-wasm/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 math-core = { path = "../math-core" }
 lol_alloc = "0.4.1"
 wasm-bindgen = "0.2.100"
+js-sys = "0.3.77"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"

--- a/math-core-wasm/src/lib.rs
+++ b/math-core-wasm/src/lib.rs
@@ -1,5 +1,7 @@
 extern crate alloc;
 
+use std::collections::HashMap;
+
 #[cfg(target_arch = "wasm32")]
 use lol_alloc::{AssumeSingleThreaded, FreeListAllocator};
 
@@ -9,6 +11,7 @@ use lol_alloc::{AssumeSingleThreaded, FreeListAllocator};
 static ALLOCATOR: AssumeSingleThreaded<FreeListAllocator> =
     unsafe { AssumeSingleThreaded::new(FreeListAllocator::new()) };
 
+use js_sys::{Array, Map};
 use math_core::{Config, Converter, Display};
 use wasm_bindgen::prelude::*;
 
@@ -24,18 +27,46 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     fn pretty(this: &JsConfig) -> bool;
+
+    #[wasm_bindgen(method, getter)]
+    fn macros(this: &JsConfig) -> Map;
 }
 
 #[wasm_bindgen]
-pub fn convert(content: &str, block: bool, js_config: JsConfig) -> Result<JsValue, LatexError> {
+pub fn convert(content: &str, block: bool, js_config: &JsConfig) -> Result<JsValue, LatexError> {
     // This is the poor man's `serde_wasm_bindgen::from_value`.
+    let macro_map = js_config.macros();
+    let mut macros = HashMap::with_capacity(macro_map.size() as usize);
+    let macro_iter = macro_map.entries();
+    loop {
+        let Ok(entry) = macro_iter.next() else {
+            break; // Exit the loop on error.
+        };
+        if entry.done() {
+            break; // Exit the loop when there are no more entries.
+        }
+        let Ok(value) = entry.value().dyn_into::<Array>() else {
+            continue; // Skip if the value is not an Array.
+        };
+        let Some(key) = value.get(0).as_string() else {
+            continue; // Skip if the first element is not a string.
+        };
+        let Some(value) = value.get(1).as_string() else {
+            continue; // Skip if the second element is not a string.
+        };
+        macros.insert(key, value);
+    }
     let config = Config {
         pretty: js_config.pretty(),
+        macros,
         ..Default::default()
     };
-    let mut converter = Converter::new(&config).map_err(|e| LatexError {
-        error_message: JsValue::from_str(&e.to_string()),
-        location: 0,
+    let mut converter = Converter::new(&config).map_err(|e| {
+        let error = e.1.string() + "\n(This is an error from a custom macro.)";
+        LatexError {
+            error_message: JsValue::from_str(&error),
+            location: e.0 as u32,
+        }
     })?;
 
     match converter.latex_to_mathml(

--- a/math-core-wasm/src/lib.rs
+++ b/math-core-wasm/src/lib.rs
@@ -33,7 +33,10 @@ pub fn convert(content: &str, block: bool, js_config: JsConfig) -> Result<JsValu
         pretty: js_config.pretty(),
         ..Default::default()
     };
-    let mut converter = Converter::new(config);
+    let mut converter = Converter::new(&config).map_err(|e| LatexError {
+        error_message: JsValue::from_str(&e.to_string()),
+        location: 0,
+    })?;
 
     match converter.latex_to_mathml(
         content,

--- a/math-core/examples/equations.rs
+++ b/math-core/examples/equations.rs
@@ -63,7 +63,11 @@ fn main() {
         r"\oint_C {\vec{B}\circ} \mathrm{d}\vec{l} = \mu_0 \left( I_{\text{enc}} + \varepsilon_0 \frac{\mathrm{d}}{\mathrm{d} t} \int_S {\vec{E} \circ \hat{n}}\; \mathrm{d} a \right)",
     ];
 
-    let mut converter = Converter::new(Config { pretty: true });
+    let mut converter = Converter::new(&Config {
+        pretty: true,
+        ..Default::default()
+    })
+    .unwrap();
     let outputs = inputs
         .iter()
         .map(|input| {

--- a/math-core/src/latex_parser/lexer.rs
+++ b/math-core/src/latex_parser/lexer.rs
@@ -145,7 +145,7 @@ impl<'config, 'source> Lexer<'config, 'source> {
                     // In pre-defined commands, `#` is used to denote a parameter.
                     let next = self.read_char().1;
                     let param_num = (next as u32).wrapping_sub('0' as u32) as usize;
-                    Token::CustomCmdArg(param_num)
+                    Token::CustomCmdArg(param_num.saturating_sub(1))
                 } else {
                     Token::Letter('#')
                 }
@@ -261,5 +261,22 @@ mod tests {
             }
             assert_snapshot!(name, &tokens, problem);
         }
+    }
+
+    #[test]
+    fn test_parsing_custom_commands() {
+        let parsing_custom_cmds = true;
+        let problem = r"\frac{#1}{#2} + \sqrt{#3}";
+        let mut lexer = Lexer::new(problem, parsing_custom_cmds, None);
+        let mut tokens = String::new();
+        loop {
+            let tokloc = lexer.next_token();
+            if matches!(tokloc.token(), Token::EOF) {
+                break;
+            }
+            let TokLoc(loc, tok) = tokloc;
+            write!(tokens, "{}: {:?}\n", loc, tok).unwrap();
+        }
+        assert_snapshot!("parsing_custom_commands", tokens, problem);
     }
 }

--- a/math-core/src/latex_parser/lexer.rs
+++ b/math-core/src/latex_parser/lexer.rs
@@ -9,23 +9,26 @@ use crate::CustomCmds;
 use crate::mathml_renderer::symbol;
 
 /// Lexer
-pub(crate) struct Lexer<'config, 'source> {
+pub(crate) struct Lexer<'source> {
     input: CharIndices<'source>,
     peek: (usize, char),
     input_string: &'source str,
     pub input_length: usize,
     pub text_mode: bool,
     parsing_custom_cmds: bool,
-    custom_cmds: Option<&'config CustomCmds>,
+    custom_cmds: Option<&'source CustomCmds>,
 }
 
-impl<'config, 'source> Lexer<'config, 'source> {
+impl<'source> Lexer<'source> {
     /// Receive the input source code and generate a LEXER instance.
-    pub(crate) fn new(
+    pub(crate) fn new<'config>(
         input: &'source str,
         parsing_custom_cmds: bool,
         custom_cmds: Option<&'config CustomCmds>,
-    ) -> Self {
+    ) -> Self
+    where
+        'config: 'source,
+    {
         let mut lexer = Lexer {
             input: input.char_indices(),
             peek: (0, '\u{0}'),
@@ -118,10 +121,7 @@ impl<'config, 'source> Lexer<'config, 'source> {
     ///
     /// If `wants_arg` is `true`, the lexer will not collect digits into a number token,
     /// but rather immediately return a single digit as a number token.
-    pub(crate) fn next_token(&mut self) -> TokLoc<'source>
-    where
-        'config: 'source,
-    {
+    pub(crate) fn next_token(&mut self) -> TokLoc<'source> {
         if let Some(loc) = self.skip_whitespace() {
             if self.text_mode {
                 return TokLoc(loc.get(), Token::Whitespace);

--- a/math-core/src/latex_parser/mod.rs
+++ b/math-core/src/latex_parser/mod.rs
@@ -10,5 +10,5 @@ mod token;
 
 pub use error::{LatexErrKind, LatexError};
 pub(crate) use lexer::Lexer;
-pub(crate) use parse::Parser;
+pub(crate) use parse::{Parser, node_vec_to_node};
 pub use token::Token;

--- a/math-core/src/latex_parser/parse.rs
+++ b/math-core/src/latex_parser/parse.rs
@@ -990,6 +990,7 @@ where
                 let args = self.arena.push_slice(&nodes);
                 Node::CustomCmd { predefined, args }
             }
+            Token::CustomCmdArg(arg_num) => Node::CustomCmdArg(arg_num),
             Token::GetCollectedLetters => match self.collector {
                 LetterCollector::FinishedOneLetter { collected_letter } => {
                     self.collector = LetterCollector::Collecting;
@@ -1446,7 +1447,7 @@ mod tests {
         ];
         for (name, problem) in problems.into_iter() {
             let arena = Arena::new();
-            let l = Lexer::new(problem);
+            let l = Lexer::new(problem, false);
             let mut p = Parser::new(l, &arena);
             let ast = p.parse().expect("Parsing failed");
             assert_ron_snapshot!(name, &ast, problem);

--- a/math-core/src/latex_parser/parse.rs
+++ b/math-core/src/latex_parser/parse.rs
@@ -21,8 +21,8 @@ use super::{
     token::{TokLoc, Token},
 };
 
-pub(crate) struct Parser<'config, 'arena, 'source> {
-    l: Lexer<'config, 'source>,
+pub(crate) struct Parser<'arena, 'source> {
+    l: Lexer<'source>,
     peek: TokLoc<'source>,
     buffer: Buffer,
     arena: &'arena Arena,
@@ -59,12 +59,11 @@ impl SequenceEnd {
     }
 }
 
-impl<'config, 'arena, 'source> Parser<'config, 'arena, 'source>
+impl<'arena, 'source> Parser<'arena, 'source>
 where
     'source: 'arena, // The reference to the source string will live as long as the arena.
-    'config: 'source,
 {
-    pub(crate) fn new(lexer: Lexer<'config, 'source>, arena: &'arena Arena) -> Self {
+    pub(crate) fn new(lexer: Lexer<'source>, arena: &'arena Arena) -> Self {
         let input_length = lexer.input_length;
         let mut p = Parser {
             l: lexer,
@@ -1221,13 +1220,7 @@ where
 }
 
 #[inline]
-fn next_token<'config, 'source>(
-    peek: &mut TokLoc<'source>,
-    lexer: &mut Lexer<'config, 'source>,
-) -> TokLoc<'source>
-where
-    'config: 'source,
-{
+fn next_token<'source>(peek: &mut TokLoc<'source>, lexer: &mut Lexer<'source>) -> TokLoc<'source> {
     let peek_token = lexer.next_token();
     // Return the previous peek token and store the new peek token.
     mem::replace(peek, peek_token)
@@ -1262,21 +1255,18 @@ enum LetterCollector<'arena> {
     FinishedManyLetters { collected_letters: &'arena str },
 }
 
-struct TextModeParser<'config, 'builder, 'source, 'parser> {
+struct TextModeParser<'builder, 'source, 'parser> {
     builder: &'builder mut StringBuilder<'parser>,
     peek: &'parser mut TokLoc<'source>,
-    lexer: &'parser mut Lexer<'config, 'source>,
+    lexer: &'parser mut Lexer<'source>,
     tf: Option<TextTransform>,
 }
 
-impl<'config, 'builder, 'source, 'parser> TextModeParser<'config, 'builder, 'source, 'parser>
-where
-    'config: 'source,
-{
+impl<'builder, 'source, 'parser> TextModeParser<'builder, 'source, 'parser> {
     fn new(
         builder: &'builder mut StringBuilder<'parser>,
         peek: &'parser mut TokLoc<'source>,
-        lexer: &'parser mut Lexer<'config, 'source>,
+        lexer: &'parser mut Lexer<'source>,
     ) -> Self {
         Self {
             builder,

--- a/math-core/src/latex_parser/snapshots/math_core__latex_parser__lexer__tests__parsing_custom_commands.snap
+++ b/math-core/src/latex_parser/snapshots/math_core__latex_parser__lexer__tests__parsing_custom_commands.snap
@@ -1,0 +1,16 @@
+---
+source: math-core/src/latex_parser/lexer.rs
+expression: "\\frac{#1}{#2} + \\sqrt{#3}"
+---
+0: Frac(None)
+5: GroupBegin
+6: CustomCmdArg(0)
+8: GroupEnd
+9: GroupBegin
+10: CustomCmdArg(1)
+12: GroupEnd
+14: BinaryOp(Bin('+'))
+16: Sqrt
+21: GroupBegin
+22: CustomCmdArg(2)
+24: GroupEnd

--- a/math-core/src/latex_parser/token.rs
+++ b/math-core/src/latex_parser/token.rs
@@ -102,6 +102,7 @@ pub enum Token<'source> {
     Style(Style),
     Color,
     CustomCmd(usize, &'static Node<'static>),
+    CustomCmdArg(usize),
     GetCollectedLetters,
     HardcodedMathML(&'static str),
     TextModeAccent(char),

--- a/math-core/src/latex_parser/token.rs
+++ b/math-core/src/latex_parser/token.rs
@@ -101,7 +101,7 @@ pub enum Token<'source> {
     Text(Option<TextTransform>),
     Style(Style),
     Color,
-    CustomCmd(usize, &'static Node<'static>),
+    CustomCmd(usize, &'source Node<'source>),
     CustomCmdArg(usize),
     GetCollectedLetters,
     HardcodedMathML(&'static str),

--- a/math-core/src/lib.rs
+++ b/math-core/src/lib.rs
@@ -102,7 +102,7 @@ pub struct Converter {
 }
 
 impl Converter {
-    pub fn new<'source>(config: &'source Config) -> Result<Self, LatexError<'source>> {
+    pub fn new(config: &Config) -> Result<Self, LatexError<'_>> {
         Ok(Self {
             pretty: config.pretty,
             equation_count: 0,
@@ -186,7 +186,7 @@ fn parse_custom_commands<'source>(
     macros: &'source HashMap<String, String>,
 ) -> Result<CustomCmds, LatexError<'source>> {
     let arena = Arena::new();
-    let mut map = HashMap::new();
+    let mut map = HashMap::with_capacity(macros.len());
     let mut parsed_macros = Vec::with_capacity(macros.len());
     for (name, definition) in macros.iter() {
         let nodes = parse(definition, &arena, true, None)?;

--- a/math-core/src/mathml_renderer/arena.rs
+++ b/math-core/src/mathml_renderer/arena.rs
@@ -32,6 +32,15 @@ impl Arena {
         }
     }
 
+    pub fn contains_slice(&self, nodes: &[&Node<'_>]) -> bool {
+        if nodes.is_empty() {
+            // We consider an empty slice to be contained in the arena.
+            true
+        } else {
+            self.inner.contains_slice(nodes)
+        }
+    }
+
     fn alloc_str(&self, src: &str) -> &str {
         // `DroplessArena::alloc_str()` panics on empty strings.
         if src.is_empty() {

--- a/math-core/src/mathml_renderer/ast.rs
+++ b/math-core/src/mathml_renderer/ast.rs
@@ -132,15 +132,15 @@ pub enum Node<'arena> {
         content: &'arena Node<'arena>,
     },
     CustomCmd {
-        predefined: &'static Node<'static>,
+        predefined: &'arena Node<'arena>,
         args: &'arena [&'arena Node<'arena>],
     },
     CustomCmdArg(usize),
     HardcodedMathML(&'static str),
 }
 
-impl PartialEq for &'static Node<'static> {
-    fn eq(&self, other: &&'static Node<'static>) -> bool {
+impl PartialEq for &Node<'_> {
+    fn eq(&self, other: &&Node<'_>) -> bool {
         std::ptr::eq(*self, *other)
     }
 }

--- a/math-core/src/raw_node_slice.rs
+++ b/math-core/src/raw_node_slice.rs
@@ -1,0 +1,66 @@
+use super::{Arena, Node};
+
+pub struct RawNodeSlice {
+    ptr: *const &'static Node<'static>,
+    len: usize,
+}
+
+impl RawNodeSlice {
+    pub fn from_slice(slice: &[&Node<'_>]) -> Self {
+        Self {
+            ptr: unsafe {
+                std::mem::transmute::<*const &Node<'_>, *const &'static Node<'static>>(
+                    slice.as_ptr(),
+                )
+            },
+            len: slice.len(),
+        }
+    }
+
+    pub fn lift<'arena>(&self, arena: &'arena Arena) -> Option<&'arena [&'arena Node<'arena>]> {
+        let ptr = unsafe {
+            std::mem::transmute::<*const &'static Node<'static>, *const &'arena Node<'arena>>(
+                self.ptr,
+            )
+        };
+        let slice = unsafe { std::slice::from_raw_parts(ptr, self.len) };
+        arena.contains_slice(slice).then(|| {
+            // SAFETY: Slice and references are guaranteed to be valid for the lifetime of the arena.
+            unsafe {
+                std::mem::transmute::<&[&'arena Node<'arena>], &'arena [&'arena Node<'arena>]>(
+                    slice,
+                )
+            }
+        })
+    }
+}
+
+// SAFETY: `RawNodeSlice` is a thin wrapper around a pointer and length, and does not
+// contain any interior mutability or unsafe operations that would violate thread safety.
+unsafe impl Send for RawNodeSlice {}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn raw_node_slice_test() {
+        let arena = Arena::new();
+        let node1 = arena.push(Node::HardcodedMathML("Node 1"));
+        let node2 = arena.push(Node::HardcodedMathML("Node 2"));
+        let slice = arena.push_slice(&[node1, node2]);
+
+        let raw_slice = RawNodeSlice::from_slice(slice);
+
+        thread::spawn(move || {
+            let lifted = raw_slice.lift(&arena).unwrap();
+            assert_eq!(lifted.len(), 2);
+            assert!(matches!(lifted[0], &Node::HardcodedMathML("Node 1")));
+            assert!(matches!(lifted[1], &Node::HardcodedMathML("Node 2")));
+        })
+        .join()
+        .unwrap();
+    }
+}

--- a/math-core/src/snapshots/math_core__tests__custom_cmds.snap
+++ b/math-core/src/snapshots/math_core__tests__custom_cmds.snap
@@ -1,0 +1,12 @@
+---
+source: math-core/src/lib.rs
+expression: mathml
+---
+<math>
+    <mi>x</mi>
+    <mo>=</mo>
+    <mfrac>
+        <mn>1</mn>
+        <mn>2</mn>
+    </mfrac>
+</math>

--- a/math-core/tests/wiki_test.rs
+++ b/math-core/tests/wiki_test.rs
@@ -873,7 +873,7 @@ fn wiki_test() {
     let mut n_match = 0usize;
     let mut n_diff = 0usize;
     let mut n_fail = 0usize;
-    let mut converter = Converter::new(Config::default());
+    let mut converter = Converter::new(&Config::default()).unwrap();
     for (i, (latex, correct)) in problems.into_iter().enumerate() {
         let with_row = "{".to_string() + latex + "}";
         converter.reset_equation_count();
@@ -1386,7 +1386,11 @@ fn test_nonfailing_wiki_tests() {
         ),
     ];
 
-    let mut converter = Converter::new(Config { pretty: true });
+    let mut converter = Converter::new(&Config {
+        pretty: true,
+        ..Default::default()
+    })
+    .unwrap();
     for (num, problem) in problems.into_iter() {
         let mathml = converter
             .latex_to_mathml(problem, crate::Display::Inline)

--- a/playground/main.js
+++ b/playground/main.js
@@ -2,7 +2,7 @@ import { convert } from "./pkg/math_core_wasm.js";
 
 // Global cached values
 let cachedIsBlock = true; // default value
-let cachedConfig = { pretty: true }; // default value
+let cachedConfig = { pretty: true, macros: new Map() }; // default value
 
 function initializeCachedValues() {
   // Initialize cached values based on current DOM state
@@ -14,7 +14,12 @@ function initializeCachedValues() {
   const prettyRadio = document.querySelector(
     '#prettyprint input[type="radio"]:checked',
   );
-  cachedConfig = { pretty: prettyRadio ? prettyRadio.value === "true" : true };
+  let macros = new Map();
+  macros.set("half", "\\frac{1}{2}");
+  cachedConfig = {
+    pretty: prettyRadio ? prettyRadio.value === "true" : true,
+    macros,
+  };
 }
 
 function updateIsBlockCache() {
@@ -30,6 +35,7 @@ function updateConfigCache() {
   );
   cachedConfig = {
     pretty: selectedRadio ? selectedRadio.value === "true" : true,
+    macros: {},
   };
 }
 

--- a/playground/main.js
+++ b/playground/main.js
@@ -35,7 +35,7 @@ function updateConfigCache() {
   );
   cachedConfig = {
     pretty: selectedRadio ? selectedRadio.value === "true" : true,
-    macros: {},
+    macros: new Map(),
   };
 }
 


### PR DESCRIPTION
Still missing:

- commands with arguments (the problem here is actually just counting them)
- exposing this functionality on the playground
- making the WASM code smaller