### PR TITLE
Remove `\textstyle` command from text mode

### DIFF
--- a/math-core/src/latex_parser/commands.rs
+++ b/math-core/src/latex_parser/commands.rs
@@ -742,7 +742,6 @@ static TEXT_COMMANDS: phf::Map<&'static str, Token> = phf::phf_map! {
     "textbackslash" => Letter('\\'),
     "textbf" => Text(Some(TextTransform::Bold)),
     "textit" => Text(Some(TextTransform::Italic)),
-    "textstyle" => Style(Style::Text),
     "texttt" => Text(Some(TextTransform::Monospace)),
     "textyen" => Letter('¥'),
     "u" => TextModeAccent(symbol::COMBINING_BREVE),


### PR DESCRIPTION
The equivalent in text mode is `\normalsize`.