### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "math-core"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "ariadne",
  "insta",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-cli"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "ariadne",
  "clap",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-python"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "ariadne",
  "math-core",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-renderer-internal"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "bitflags",
  "dtoa",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-wasm"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "ariadne",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"
-version = "0.6.4"
+version = "0.7.0"
 repository = "https://github.com/tmke8/math-core"
 
 [workspace.dependencies]

--- a/crates/math-core-cli/Cargo.toml
+++ b/crates/math-core-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-math-core = { path = "../math-core", features = ["serde", "ariadne"], version = "0.6.4" }
+math-core = { path = "../math-core", features = ["serde", "ariadne"], version = "0.7.0" }
 ariadne = { workspace = true }
 memchr = { workspace = true }
 phf = { version = "0.13.1", features = ["macros"] }

--- a/crates/math-core/Cargo.toml
+++ b/crates/math-core/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["science"]
 exclude = ["/src/snapshots", "/tests/snapshots"]
 
 [dependencies]
-mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.6.4" }
+mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.7.0" }
 serde = { workspace = true, optional = true }
 serde-tuple-vec-map = { version = "1.0.1", optional = true }
 phf = { version = "0.13.1", features = ["macros"] }
@@ -32,7 +32,7 @@ ariadne = { workspace = true, optional = true }
 
 [dev-dependencies]
 math-core = { path = ".", features = ["serde", "ariadne"] }
-mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.6.4", features = ["serde"] }
+mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.7.0", features = ["serde"] }
 insta = { version = "1.47.2", features = ["default", "ron"] }
 regex = "1.12.3"
 minijinja = "2.20.0"

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "math-core",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "math-core",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^5.2.2",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "math-core",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Convert LaTeX to MathML Core",
   "homepage": "https://github.com/tmke8/math-core#readme",
   "bugs": {


### PR DESCRIPTION



## 🤖 New release

* `math-core-renderer-internal`: 0.6.4 -> 0.7.0
* `math-core`: 0.6.4 -> 0.7.0 (⚠ API breaking changes)
* `math-core-cli`: 0.6.4 -> 0.7.0

### ⚠ `math-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MathCoreConfig.unicode_substitution in /tmp/.tmpY0BS3n/math-core/crates/math-core/src/lib.rs:163
  field MathCoreConfig.css_classes in /tmp/.tmpY0BS3n/math-core/crates/math-core/src/lib.rs:165
  field MathCoreConfig.indentation in /tmp/.tmpY0BS3n/math-core/crates/math-core/src/lib.rs:168

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  LatexToMathML::convert_with_global_counter, previously in file /tmp/.tmpbmxsNG/math-core/src/lib.rs:200
  LatexToMathML::convert_with_local_counter, previously in file /tmp/.tmpbmxsNG/math-core/src/lib.rs:234
  LatexToMathML::reset_global_counter, previously in file /tmp/.tmpbmxsNG/math-core/src/lib.rs:254
```

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).