### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "math-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ariadne",
  "hashbrown 0.17.1",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ariadne",
  "clap",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-python"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ariadne",
  "math-core",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-renderer-internal"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags",
  "dtoa",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "math-core-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ariadne",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 repository = "https://github.com/tmke8/math-core"
 
 [workspace.dependencies]

--- a/crates/math-core-cli/Cargo.toml
+++ b/crates/math-core-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-math-core = { path = "../math-core", features = ["serde", "ariadne"], version = "0.7.0" }
+math-core = { path = "../math-core", features = ["serde", "ariadne"], version = "0.8.0" }
 ariadne = { workspace = true }
 memchr = { workspace = true }
 phf = { version = "0.14.0", features = ["macros"] }

--- a/crates/math-core/Cargo.toml
+++ b/crates/math-core/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["science"]
 exclude = ["/src/snapshots", "/tests/snapshots"]
 
 [dependencies]
-mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.7.0", default-features = false }
+mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.8.0", default-features = false }
 serde = { version = "1.0.228", optional = true, default-features = false, features = ["derive", "alloc"] }
 serde-tuple-vec-map = { version = "1.0.1", optional = true, default-features = false }
 phf = { version = "0.14.0", default-features = false, features = ["macros", "ptrhash"] }
@@ -34,7 +34,7 @@ ariadne = { workspace = true, optional = true }
 
 [dev-dependencies]
 math-core = { path = ".", features = ["serde", "ariadne"] }
-mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.7.0", features = ["serde"] }
+mathml-renderer = { path = "../mathml-renderer", package = "math-core-renderer-internal", version = "0.8.0", features = ["serde"] }
 insta = { version = "1.47.2", features = ["default", "ron"] }
 similar = "3.2.0"
 minijinja = "2.20.0"

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "math-core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "math-core",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^5.2.2",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "math-core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Convert LaTeX to MathML Core",
   "homepage": "https://github.com/tmke8/math-core#readme",
   "bugs": {


### PR DESCRIPTION



## 🤖 New release

* `math-core-renderer-internal`: 0.7.0 -> 0.8.0
* `math-core`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `math-core-cli`: 0.7.0 -> 0.8.0

### ⚠ `math-core` breaking changes

```text
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Description:
A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MathCoreConfig.global_group in /tmp/.tmpUlJ4fc/math-core/crates/math-core/src/lib.rs:217
  field MathCoreConfig.max_expansions in /tmp/.tmpUlJ4fc/math-core/crates/math-core/src/lib.rs:228
  field MathCoreConfig.id_prefix in /tmp/.tmpUlJ4fc/math-core/crates/math-core/src/lib.rs:232

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  math_core::LatexToMathML::convert_all takes 1 generic types instead of 0, in /tmp/.tmpUlJ4fc/math-core/crates/math-core/src/lib.rs:383
```

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).