### PR TITLE
Support `\hline` and `\hdashline` in matrices

### DIFF
--- a/crates/math-core/src/environments.rs
+++ b/crates/math-core/src/environments.rs
@@ -8,7 +8,7 @@ use mathml_renderer::{
     ast::Node,
     attribute::Style,
     symbol,
-    table::{Alignment, ArraySpec, RowLabelInfo},
+    table::{Alignment, ArraySpec, LineType, RowLabelInfo},
 };
 
 use crate::character_class::{StretchableOp, fenced};
@@ -98,6 +98,24 @@ impl Env {
         )
     }
 
+    /// `true` for environments in which `\hline`/`\hdashline` may appear (the `array` family and
+    /// the `matrix` family).
+    #[inline]
+    pub(super) fn allows_hlines(self) -> bool {
+        matches!(
+            self,
+            Env::Array
+                | Env::DArray
+                | Env::Subarray
+                | Env::Matrix
+                | Env::PMatrix
+                | Env::BMatrix
+                | Env::Bmatrix
+                | Env::VMatrix
+                | Env::Vmatrix
+        )
+    }
+
     #[inline]
     fn get_numbered_env_state(self) -> Option<NumberedEnvState<'static>> {
         if matches!(
@@ -132,7 +150,7 @@ impl Env {
         EnvState {
             allow_columns: self.allows_columns(),
             meaningful_newlines: !matches!(self, Env::Equation | Env::EquationStar),
-            in_array: matches!(self, Env::Array | Env::DArray | Env::Subarray),
+            allow_hlines: self.allows_hlines(),
             numbered: self.get_numbered_env_state(),
         }
     }
@@ -156,6 +174,7 @@ impl Env {
         arena: &'arena Arena,
         last_row_info: Option<&'arena RowLabelInfo<'arena>>,
         num_rows: Option<NonZeroU16>,
+        border_top: Option<LineType>,
     ) -> Node<'arena> {
         match self {
             Env::Align | Env::AlignStar => Node::EquationArray {
@@ -167,6 +186,7 @@ impl Env {
                 align: Alignment::Alternating,
                 style: Some(Style::Display),
                 content,
+                border_top: None,
             },
             Env::Equation | Env::EquationStar | Env::Gather | Env::GatherStar => {
                 Node::EquationArray {
@@ -179,11 +199,13 @@ impl Env {
                 align: Alignment::Centered,
                 style: Some(Style::Display),
                 content,
+                border_top: None,
             },
             Env::Matrix => Node::Table {
                 align: Alignment::Centered,
                 style: Some(Style::Text),
                 content,
+                border_top,
             },
             Env::MultLine => {
                 debug_assert!(num_rows.is_some());
@@ -199,6 +221,7 @@ impl Env {
                     content,
                     align,
                     style: Some(Style::Text),
+                    border_top: None,
                 });
                 fenced(arena, vec![content], Some(OPEN_BRACE), None, None)
             }
@@ -208,6 +231,7 @@ impl Env {
                     content,
                     align,
                     style: Some(Style::Text),
+                    border_top: None,
                 });
                 fenced(arena, vec![content], None, Some(CLOSE_BRACE), None)
             }
@@ -217,6 +241,7 @@ impl Env {
                     content,
                     align,
                     style: Some(Style::Display),
+                    border_top: None,
                 });
                 fenced(arena, vec![content], Some(OPEN_BRACE), None, None)
             }
@@ -226,6 +251,7 @@ impl Env {
                     content,
                     align,
                     style: Some(Style::Display),
+                    border_top: None,
                 });
                 fenced(arena, vec![content], None, Some(CLOSE_BRACE), None)
             }
@@ -276,6 +302,7 @@ impl Env {
                         content,
                         align,
                         style,
+                        border_top,
                     })],
                     Some(open),
                     Some(close),
@@ -292,9 +319,9 @@ pub struct EnvState<'arena> {
     pub allow_columns: bool,
     /// `true` if we should treat newlines as meaningful (i.e., in `align` environments).
     pub meaningful_newlines: bool,
-    /// `true` if we are inside an `array`/`darray`/`subarray` environment, where `\hline` and
-    /// `\hdashline` are allowed (directly after `\\` or at the start of the environment).
-    pub in_array: bool,
+    /// `true` if we are inside an environment where `\hline` and `\hdashline` are allowed
+    /// (directly after `\\` or at the start of the environment).
+    pub allow_hlines: bool,
     pub numbered: Option<NumberedEnvState<'arena>>,
 }
 

--- a/crates/math-core/src/error.rs
+++ b/crates/math-core/src/error.rs
@@ -85,7 +85,7 @@ pub enum Place {
     TableEnv,
     #[strum(serialize = r"in a numbered equation environment")]
     NumberedEnv,
-    #[strum(serialize = r"directly after a `\\` or at the beginning of an array")]
+    #[strum(serialize = r"directly after a `\\` or at the beginning of an array or matrix")]
     ArrayRowStart,
 }
 

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -1322,7 +1322,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 })
             }
             Token::Begin(env) => 'begin_env: {
-                let array_spec = if matches!(env, Env::Array | Env::DArray | Env::Subarray) {
+                let spec = if matches!(env, Env::Array | Env::DArray | Env::Subarray) {
                     // Parse the array options.
                     let (options, span) = self.parse_string_literal()?;
                     let Some(mut spec) = parse_column_specification(options, self.arena) else {
@@ -1334,16 +1334,26 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     if matches!(env, Env::Subarray) {
                         spec.is_sub = true;
                     }
-                    // A `\hline`/`\hdashline` directly at the start of the array (whitespace is
-                    // skipped by `peek`) becomes the top border of the whole array.
-                    if let Token::HLine(line_type) = *self.tokens.peek().token() {
-                        self.tokens.next()?;
-                        spec.border_top = Some(line_type);
-                    }
-                    Some(self.arena.alloc_array_spec(spec))
+                    Some(spec)
                 } else {
                     None
                 };
+
+                // A `\hline`/`\hdashline` directly at the start of the environment (whitespace is
+                // skipped by `peek`) becomes the top border of the whole table.
+                let mut border_top = None;
+                if env.allows_hlines()
+                    && let Token::HLine(line_type) = *self.tokens.peek().token()
+                {
+                    self.tokens.next()?;
+                    border_top = Some(line_type);
+                }
+                // For arrays, the top border is stored in the array spec, which already carries
+                // the borders coming from the column specification.
+                let array_spec = spec.map(|mut spec| {
+                    spec.border_top = border_top;
+                    self.arena.alloc_array_spec(spec)
+                });
 
                 let old_style = mem::replace(&mut self.state.style, env.style());
                 let old_env_state = mem::replace(&mut self.state.env, env.new_state());
@@ -1410,7 +1420,14 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 };
                 class = Class::Close;
 
-                Ok(env.construct_node(content, array_spec, self.arena, last_row_info, num_rows))
+                Ok(env.construct_node(
+                    content,
+                    array_spec,
+                    self.arena,
+                    last_row_info,
+                    num_rows,
+                    border_top,
+                ))
             }
             Token::OperatorName { with_limits } => {
                 let snippets = self.extract_text(None, false)?;
@@ -1483,9 +1500,9 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     break 'new_line Ok(Node::EMPTY_ROW);
                 }
                 // A `\hline`/`\hdashline` directly after the `\\` (whitespace is skipped by `peek`)
-                // becomes the top border of the row that follows. Only legal inside an array;
-                // elsewhere it falls through to the `Token::HLine` error arm.
-                let border_top = if self.state.env.in_array {
+                // becomes the top border of the row that follows. Only legal inside an array or
+                // matrix; elsewhere it falls through to the `Token::HLine` error arm.
+                let border_top = if self.state.env.allow_hlines {
                     match *self.tokens.peek().token() {
                         Token::HLine(line_type) => {
                             self.tokens.next()?;

--- a/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_end.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_end.snap
@@ -6,6 +6,7 @@ expression: "\\begin{matrix}\\sum\\displaystyle\\sum\\end{matrix}"
   Table(
     align: Centered,
     style: Some(Text),
+    border_top: None,
     content: [
       Operator(
         op: "∑",

--- a/crates/math-core/src/snapshots/math_core__parser__tests__matrix.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__matrix.snap
@@ -15,6 +15,7 @@ expression: "\\begin{pmatrix} x \\\\ y \\end{pmatrix}"
       Table(
         align: Centered,
         style: Some(Text),
+        border_top: None,
         content: [
           IdentifierChar("x", Default),
           RowSeparator(

--- a/crates/math-core/src/token.rs
+++ b/crates/math-core/src/token.rs
@@ -27,8 +27,8 @@ pub enum Token<'source> {
     NewColumn,
     /// A new line in an array or matrix, e.g. `\\` in `\begin{matrix} a & b\\c & d \end{matrix}`.
     NewLine,
-    /// A horizontal rule in an array, i.e. `\hline` (solid) or `\hdashline` (dashed). Only legal
-    /// directly after a `\\` or at the very beginning of an array environment.
+    /// A horizontal rule in an array or matrix, i.e. `\hline` (solid) or `\hdashline` (dashed).
+    /// Only legal directly after a `\\` or at the very beginning of such an environment.
     HLine(LineType),
     /// `\nonumber`/`\notag`, suppresses numbering for the current equation.
     NoNumber,

--- a/crates/math-core/tests/conversion_test.rs
+++ b/crates/math-core/tests/conversion_test.rs
@@ -588,6 +588,18 @@ fn main() {
             r"\begin{array}{cc} \hline 1 & 2 \\ \hline 3 & 4 \\ \hdashline 5 & 6 \\ \hline \end{array}",
         ),
         (
+            "matrix_hlines",
+            r"\begin{matrix} \hline 1 & 2 \\ \hline 3 & 4 \\ \hdashline 5 & 6 \\ \hline \end{matrix}",
+        ),
+        (
+            "pmatrix_hlines",
+            r"\begin{pmatrix} \hdashline 1 & 2 \\ \hline 3 & 4 \end{pmatrix}",
+        ),
+        (
+            "vmatrix_hline",
+            r"\begin{vmatrix} 1 & 2 \\ \hline 3 & 4 \end{vmatrix}",
+        ),
+        (
             "subarray",
             r"\sum_{\begin{subarray}{c} 0 \le i \le m\\ 0 < j < n \end{subarray}}",
         ),

--- a/crates/math-core/tests/error_test.rs
+++ b/crates/math-core/tests/error_test.rs
@@ -94,7 +94,7 @@ fn main() {
         ),
         (
             "hline_in_non_array_env",
-            r"\begin{matrix} 1 \\ \hline 2 \end{matrix}",
+            r"\begin{cases} 1 \\ \hline 2 \end{cases}",
         ),
         ("hash_outside_macro_definition", r"x # y"),
         ("sqrt_unknown_cmd", r"\sqrt[3]\asdf 3"),

--- a/crates/math-core/tests/snapshots/conversion_test__matrix_hlines.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__matrix_hlines.snap
@@ -1,0 +1,36 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\begin{matrix} \\hline 1 & 2 \\\\ \\hline 3 & 4 \\\\ \\hdashline 5 & 6 \\\\ \\hline \\end{matrix}"
+---
+<math>
+    <mtable style="border-top: 0.05em solid currentcolor;" displaystyle="false" scriptlevel="0">
+        <mtr>
+            <mtd>
+                <mn>1</mn>
+            </mtd>
+            <mtd>
+                <mn>2</mn>
+            </mtd>
+        </mtr>
+        <mtr>
+            <mtd style="border-top: 0.05em solid currentcolor;">
+                <mn>3</mn>
+            </mtd>
+            <mtd style="border-top: 0.05em solid currentcolor;">
+                <mn>4</mn>
+            </mtd>
+        </mtr>
+        <mtr>
+            <mtd style="border-top: 0.05em dashed currentcolor;">
+                <mn>5</mn>
+            </mtd>
+            <mtd style="border-top: 0.05em dashed currentcolor;">
+                <mn>6</mn>
+            </mtd>
+        </mtr>
+        <mtr>
+            <mtd style="border-top: 0.05em solid currentcolor;">
+            </mtd>
+        </mtr>
+    </mtable>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__pmatrix_hlines.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__pmatrix_hlines.snap
@@ -1,0 +1,28 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\begin{pmatrix} \\hdashline 1 & 2 \\\\ \\hline 3 & 4 \\end{pmatrix}"
+---
+<math>
+    <mrow>
+        <mo>(</mo>
+        <mtable style="border-top: 0.05em dashed currentcolor;" displaystyle="false" scriptlevel="0">
+            <mtr>
+                <mtd>
+                    <mn>1</mn>
+                </mtd>
+                <mtd>
+                    <mn>2</mn>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd style="border-top: 0.05em solid currentcolor;">
+                    <mn>3</mn>
+                </mtd>
+                <mtd style="border-top: 0.05em solid currentcolor;">
+                    <mn>4</mn>
+                </mtd>
+            </mtr>
+        </mtable>
+        <mo>)</mo>
+    </mrow>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__vmatrix_hline.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__vmatrix_hline.snap
@@ -1,0 +1,28 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\begin{vmatrix} 1 & 2 \\\\ \\hline 3 & 4 \\end{vmatrix}"
+---
+<math>
+    <mrow>
+        <mo>|</mo>
+        <mtable displaystyle="false" scriptlevel="0">
+            <mtr>
+                <mtd>
+                    <mn>1</mn>
+                </mtd>
+                <mtd>
+                    <mn>2</mn>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd style="border-top: 0.05em solid currentcolor;">
+                    <mn>3</mn>
+                </mtd>
+                <mtd style="border-top: 0.05em solid currentcolor;">
+                    <mn>4</mn>
+                </mtd>
+            </mtr>
+        </mtable>
+        <mo>|</mo>
+    </mrow>
+</math>

--- a/crates/math-core/tests/snapshots/error_test__hline_in_non_array_env.snap
+++ b/crates/math-core/tests/snapshots/error_test__hline_in_non_array_env.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/math-core/tests/error_test.rs
-expression: "\\begin{matrix} 1 \\\\ \\hline 2 \\end{matrix}"
+expression: "\\begin{cases} 1 \\\\ \\hline 2 \\end{cases}"
 ---
-Error: Found "\hline", which may only appear directly after a `\\` or at the beginning of an array.
-   ╭─[ <input>:1:21 ]
+Error: Found "\hline", which may only appear directly after a `\\` or at the beginning of an array or matrix.
+   ╭─[ <input>:1:20 ]
    │
- 1 │ \begin{matrix} 1 \\ \hline 2 \end{matrix}
-   │                     ───┬──  
-   │                        ╰──── cannot be used here
+ 1 │ \begin{cases} 1 \\ \hline 2 \end{cases}
+   │                    ───┬──  
+   │                       ╰──── cannot be used here
 ───╯

--- a/crates/math-core/tests/snapshots/error_test__hline_in_wrong_position.snap
+++ b/crates/math-core/tests/snapshots/error_test__hline_in_wrong_position.snap
@@ -2,7 +2,7 @@
 source: crates/math-core/tests/error_test.rs
 expression: "\\begin{array}{cc} 1 & \\hline 2 \\end{array}"
 ---
-Error: Found "\hline", which may only appear directly after a `\\` or at the beginning of an array.
+Error: Found "\hline", which may only appear directly after a `\\` or at the beginning of an array or matrix.
    ╭─[ <input>:1:23 ]
    │
  1 │ \begin{array}{cc} 1 & \hline 2 \end{array}

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -153,6 +153,9 @@ pub enum Node<'arena> {
     Table {
         align: Alignment,
         style: Option<Style>,
+        /// A line above the first row, from a `\hline`/`\hdashline` at the start of the
+        /// environment.
+        border_top: Option<LineType>,
         content: &'arena [&'arena Node<'arena>],
     },
     /// `<mtable>...</mtable>` for equation arrays like the `align` environment
@@ -597,10 +600,17 @@ impl<'state> Emitter<'state> {
                 content,
                 align,
                 style,
+                border_top,
             } => {
                 let mtd_opening = ColumnGenerator::new_predefined(align);
 
                 write!(self.s, "<mtable")?;
+                // A leading `\hline`/`\hdashline` becomes a border on the table itself.
+                match border_top {
+                    Some(LineType::Solid) => write!(self.s, " style=\"{BORDER_TOP_SOLID}\"")?,
+                    Some(LineType::Dashed) => write!(self.s, " style=\"{BORDER_TOP_DASHED}\"")?,
+                    None => (),
+                }
                 if let Some(style) = style {
                     write!(self.s, "{}", <&str>::from(style))?;
                 }
@@ -1459,6 +1469,7 @@ mod tests {
                 content: &nodes,
                 align: Alignment::Centered,
                 style: None,
+                border_top: None,
             }),
             "<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>"
         );
@@ -1580,6 +1591,34 @@ mod tests {
                         },
                     ],
                 },
+            }),
+            "<mtable style=\"border-top: 0.05em solid currentcolor;\"><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd style=\"border-top: 0.05em dashed currentcolor;\"><mn>3</mn></mtd><mtd style=\"border-top: 0.05em dashed currentcolor;\"><mn>4</mn></mtd></mtr></mtable>"
+        );
+    }
+
+    #[test]
+    fn render_table_with_hlines() {
+        // Same as `render_array_with_hlines`, but for a matrix: the leading `\hline` sets
+        // `border_top` on the table itself.
+        let nodes = [
+            &Node::Number("1"),
+            &Node::ColumnSeparator,
+            &Node::Number("2"),
+            &Node::RowSeparator {
+                label_info: None,
+                border_top: Some(LineType::Dashed),
+            },
+            &Node::Number("3"),
+            &Node::ColumnSeparator,
+            &Node::Number("4"),
+        ];
+
+        assert_eq!(
+            render(&Node::Table {
+                content: &nodes,
+                align: Alignment::Centered,
+                style: None,
+                border_top: Some(LineType::Solid),
             }),
             "<mtable style=\"border-top: 0.05em solid currentcolor;\"><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd style=\"border-top: 0.05em dashed currentcolor;\"><mn>3</mn></mtd><mtd style=\"border-top: 0.05em dashed currentcolor;\"><mn>4</mn></mtd></mtr></mtable>"
         );


### PR DESCRIPTION
Previously, they were only allowed in arrays.