### PR TITLE
Fix character class of `\middle`

### DIFF
--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -1238,6 +1238,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 Ok(fenced(self.arena, content, open_paren, close_paren, None))
             }
             Token::Middle => {
+                class = Class::Open;
                 let tok_loc = self.next_token()?;
                 let op = extract_delimiter(tok_loc, DelimiterModifier::Middle)?;
                 let spacing = if matches!(op.spacing, DelimiterSpacing::Zero) {

--- a/crates/math-core/src/token.rs
+++ b/crates/math-core/src/token.rs
@@ -445,7 +445,7 @@ impl Token<'_> {
             Open(_) | Left | SquareBracketOpen | ForceOpen(..) | Begin(_) | GroupBegin => {
                 Some(Class::Open)
             }
-            Close(_) | SquareBracketClose | ForceClose(..) | Right => Some(Class::Close),
+            Close(_) | SquareBracketClose | ForceClose(..) | Right | Middle => Some(Class::Close),
             BinaryOp(_) | ForceBinaryOp(_) => Some(Class::BinaryOp),
             Op(_)
             | ForceLargeOp(..)
@@ -477,7 +477,6 @@ impl Token<'_> {
             | UprightLetter(_)
             | Digit(_)
             | Big(_, None)
-            | Middle
             | Frac(_)
             | InfixGenFrac { .. }
             | Genfrac

--- a/crates/math-core/tests/conversion_test.rs
+++ b/crates/math-core/tests/conversion_test.rs
@@ -482,6 +482,7 @@ fn main() {
             r"\left(\frac12\middle\uparrow\frac12\right)",
         ),
         ("middle_bracket", r"\left(\frac12\middle]\frac12\right)"),
+        ("middle_equality", r"\left(=\middle|=\right)"),
         ("left_right_different_stretch", r"\left/\frac12\right)"),
         ("double_struck_cmds", r"\N\R\Z"),
         ("xrightarrow", r"\xrightarrow{x}"),

--- a/crates/math-core/tests/snapshots/conversion_test__middle_equality.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__middle_equality.snap
@@ -1,0 +1,13 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\left(=\\middle|=\\right)"
+---
+<math>
+    <mrow>
+        <mo>(</mo>
+        <mo lspace="0" rspace="0">=</mo>
+        <mo stretchy="true" lspace="0" rspace="0">|</mo>
+        <mo lspace="0" rspace="0">=</mo>
+        <mo>)</mo>
+    </mrow>
+</math>


### PR DESCRIPTION
It's close from the left and open from the right.