### PR TITLE
Make all macros late-expanding

### DIFF
--- a/crates/math-core/src/custom_cmds.rs
+++ b/crates/math-core/src/custom_cmds.rs
@@ -35,9 +35,11 @@ struct CmdDef {
     /// The character class of the body, which we have to remember because
     /// [`Token::class`] cannot look into the store.
     ///
-    /// A body which begins with a command that isn't defined yet counts as an ordinary atom,
-    /// because the class has to be known here, before we can know what that command will
-    /// turn out to be.
+    /// The class is the one the body had when it was recorded, and it does not follow a later
+    /// redefinition of the command the body begins with, even though the *meaning* of that
+    /// command does. A body which begins with a command that isn't defined yet counts as an
+    /// ordinary atom, because the class has to be known here, before we can know what that
+    /// command will turn out to be.
     class: Option<Class>,
     start: usize,
     end: usize,

--- a/crates/math-core/src/lexer.rs
+++ b/crates/math-core/src/lexer.rs
@@ -41,11 +41,6 @@ impl<'source> Lexer<'source> {
         self.input_length
     }
 
-    #[inline]
-    pub(super) fn input(&self) -> &'source str {
-        self.input_string
-    }
-
     /// One character progresses.
     fn read_char(&mut self) -> (usize, Option<char>) {
         mem::replace(

--- a/crates/math-core/src/lib.rs
+++ b/crates/math-core/src/lib.rs
@@ -511,11 +511,13 @@ fn parse<'arena>(
 
 /// Read the macros of the configuration into a store of custom commands.
 ///
-/// A macro may refer to a command which is not defined here at all, and in particular to
-/// another macro of the configuration, no matter in which order the two are given: such a
-/// reference is kept as a [`Token::UnresolvedCommand`] and resolved when the macro is used.
-/// Once all macros have been read, every one of those references must point at something,
-/// which is what the final check is for.
+/// As in a body recorded from a `\newcommand`, every command is kept as a
+/// [`Token::UnresolvedCommand`] and only resolved when the macro is used. A macro may
+/// therefore refer to a command which is not defined here at all, and in particular to another
+/// macro of the configuration, no matter in which order the two are given. Once all macros have
+/// been read, every one of those references must point at something, which is what the final
+/// check is for; a document definition, which has no such point in time, is only checked when
+/// it is used.
 fn parse_custom_commands(
     macros: Vec<(String, String)>,
     unicode_substitution: UnicodeSubstitution,

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -21,6 +21,7 @@ use crate::{
         Class, DelimiterSpacing, MathVariant, ParenType, StretchableOp, Stretchy, fenced,
     },
     color_defs::get_color,
+    custom_cmds::CmdSource,
     environments::{
         CLOSE_BRACE, CLOSE_BRACKET, CLOSE_PAREN, Env, EnvState, OPEN_BRACE, OPEN_BRACKET,
         OPEN_PAREN,
@@ -54,7 +55,7 @@ pub(crate) struct Parser<'state, 'arena> {
 struct ParserState<'arena> {
     /// The arguments of the custom command which is being expanded right now. They are only
     /// needed until the body has been queued, so this is really just a reusable buffer.
-    cmd_args: CmdArgs,
+    cmd_args: CmdArgs<'arena>,
     transform: Option<MathVariant>,
     /// `true` if the boundaries at the end of a sequence are not real boundaries;
     /// this is not the case for style-only rows.
@@ -2239,6 +2240,11 @@ impl<'state, 'arena> Parser<'state, 'arena> {
     /// The `mode` decides what happens when the name is (not) already defined:
     /// `\providecommand` parses the definition as usual and then throws it away if the name is
     /// taken, and `\renewcommand` requires the name to be taken and overwrites the definition.
+    ///
+    /// The body is recorded by name: a command in it means whatever its name means when the
+    /// command being defined here is expanded, not what it meant while the body was being read.
+    /// A body which mentions the command it is the body of therefore recurses, as it does in
+    /// LaTeX, and is stopped by the expansion limit rather than by the old definition.
     fn define_command(&mut self, mode: DefineMode) -> ParseResult<()> {
         // The name of the new command, optionally wrapped in braces.
         let braced = matches!(self.tokens.peek().token(), Token::GroupBegin);
@@ -2268,10 +2274,10 @@ impl<'state, 'arena> Parser<'state, 'arena> {
             }
             // Any other token means that the name was already defined.
             _ => {
-                let span = name_tokspan.span();
-                // The name as it appears in the source, without the leading backslash.
-                let name = self.tokens.command_name_from_span(span);
-                let span: Range<usize> = span.into();
+                // The name the token came from, which is `None` if it didn't come from a
+                // command at all.
+                let name = name_tokspan.name();
+                let span: Range<usize> = name_tokspan.span().into();
                 let Some(name) = name else {
                     return Err(Box::new(LatexError(
                         span,
@@ -2289,7 +2295,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     // The name may belong to a builtin command or to a macro from the
                     // configuration; in both cases, the new definition shadows the old one,
                     // because resolution looks in the document's definitions first.
-                    DefineMode::Renew => Some((self.arena.alloc_str(name), true)),
+                    DefineMode::Renew => Some((name, true)),
                 }
             }
         };
@@ -2337,45 +2343,61 @@ impl<'state, 'arena> Parser<'state, 'arena> {
             // `record_macro_body` leaves the closing `}` for us.
             self.next_token()?;
         } else {
-            let tokspan = self.next_token()?;
-            if matches!(tokspan.token(), Token::Eoi) {
+            let queued = self.tokens.next_keeping_name()?;
+            if matches!(queued.token(), Token::Eoi) {
                 return Err(Box::new(LatexError(
-                    tokspan.span().into(),
+                    queued.span().into(),
                     LatexErrKind::ExpectedArgumentGotEOI,
                 )));
             }
             // A body which isn't a group consists of a single token.
-            body_tokspans.push(tokspan);
+            body_tokspans.push(queued);
         }
 
         let mut first_class: Option<Class> = None;
         let mut body = body_tokspans
             .into_iter()
-            .map(|tokspan| {
-                let (tok, span) = tokspan.into_parts();
+            .map(|queued| {
+                let (tok, span) = queued.into_tokspan().into_parts();
                 match tok {
                     Token::CustomCmdArgInput(arg_num) => {
                         if arg_num >= num_args {
-                            Err(Box::new(LatexError(
+                            return Err(Box::new(LatexError(
                                 span.into(),
                                 LatexErrKind::ParameterNumberOutOfRange {
                                     actual: arg_num + 1,
                                     n: num_args,
                                 },
-                            )))
-                        } else {
-                            Ok(Token::CustomCmdArg(arg_num))
+                            )));
                         }
+                        Ok(Token::CustomCmdArg(arg_num))
                     }
+                    // This has to come before the arm below, which would otherwise record
+                    // `\newcommand` by name like any other command.
                     Token::NewCommand(_) => Err(Box::new(LatexError(
                         span.into(),
                         LatexErrKind::CannotBeUsedAsArgument,
                     ))),
                     tok => {
+                        // The class has to be known now, because it is stored with the
+                        // definition, so we take it from the meaning the command has here.
                         if first_class.is_none() {
                             first_class = tok.class();
                         }
-                        Ok(tok)
+                        match queued.name() {
+                            // A command is recorded by name rather than by what it means right
+                            // now, so that the body follows a later redefinition of that name,
+                            // the way it does in LaTeX. An unresolved command already holds its
+                            // name, so it is left alone.
+                            Some(name) if !matches!(tok, Token::UnresolvedCommand(_, _)) => {
+                                let name = self.tokens.stores.local_cmds.intern(name);
+                                Ok(Token::UnresolvedCommand(CmdSource::Local, name))
+                            }
+                            // Anything which didn't come from a command name keeps its meaning:
+                            // ordinary characters, and `\begin`/`\end`, whose meaning the lexer
+                            // decides.
+                            _ => Ok(tok),
+                        }
                     }
                 }
             })
@@ -2425,20 +2447,22 @@ impl<'state, 'arena> Parser<'state, 'arena> {
     fn read_cmd_args(&mut self, num_args: u8) -> ParseResult<()> {
         self.state.cmd_args.clear();
         for arg_num in 0..num_args {
-            let tokspan = self.next_token()?;
-            match tokspan.token() {
+            // The tokens keep the names they came from, so that an argument which is
+            // substituted into a `\newcommand` can be recorded by name like any other token.
+            let queued = self.tokens.next_keeping_name()?;
+            match queued.token() {
                 Token::GroupBegin => {
                     self.tokens
                         .record_group(self.state.cmd_args.buffer(), true)?;
                 }
                 Token::Eoi => {
                     return Err(Box::new(LatexError(
-                        tokspan.span().into(),
+                        queued.span().into(),
                         LatexErrKind::ExpectedArgumentGotEOI,
                     )));
                 }
                 // An argument which isn't a group consists of a single token.
-                _ => self.state.cmd_args.push(tokspan),
+                _ => self.state.cmd_args.push(queued),
             }
             self.state.cmd_args.finish_arg(arg_num);
         }

--- a/crates/math-core/src/token.rs
+++ b/crates/math-core/src/token.rs
@@ -222,9 +222,11 @@ pub enum Token {
     /// A token which changes the meaning of the character `|` for the rest of the
     /// surrounding sequence. This is how `\set`, `\Set` and `\Braket` "redefine" `|`.
     VerticalLineDef(Option<VerticalLineDef>),
-    /// A command that hasn't been resolved yet. The `InternedStr` is an index into the
-    /// [`StringPool`](crate::string_pool::StringPool) which belongs to the given [`CmdSource`];
-    /// it can be resolved with
+    /// A command that hasn't been resolved yet, either because nothing of that name is defined
+    /// (yet) or because it stands in the body of a custom command, where names are deliberately
+    /// left to be resolved every time the command is expanded. The `InternedStr` is an index into
+    /// the [`StringPool`](crate::string_pool::StringPool) which belongs to the given
+    /// [`CmdSource`]; it can be resolved with
     /// [`Stores::name_in_pool`](crate::token_queue::Stores::name_in_pool).
     UnresolvedCommand(CmdSource, InternedStr),
     /// This token is intended to be used in predefined token streams.

--- a/crates/math-core/src/token_queue.rs
+++ b/crates/math-core/src/token_queue.rs
@@ -7,7 +7,7 @@ use crate::{
     ParserConfig,
     character_class::Class,
     commands::resolve_builtin_cmd,
-    custom_cmds::{CmdSource, CustomCmds, is_valid_macro_name},
+    custom_cmds::{CmdSource, CustomCmds},
     error::{LatexErrKind, LatexError},
     global_state::GlobalState,
     lexer::{Lexer, LexerOutput},
@@ -18,15 +18,102 @@ use crate::{
 /// A token queue that allows peeking at the next non-whitespace token.
 ///
 /// This is also where command names are given their meaning: the lexer hands out a
-/// [`Token::CommandName`] for every command it reads, and it is resolved here, both when it
-/// comes out of the lexer and when it comes out of the body of a custom command. The latter is
-/// what makes it possible for a body to mention a command which is only defined later.
+/// [`LexerOutput::CommandName`] for every command it reads, and it is resolved here, both when
+/// it comes out of the lexer and when it comes out of the body of a custom command. The latter
+/// is what makes it possible for a body to mention a command which is only defined later.
+///
+/// The queue holds on to the name a command came from, next to the meaning it was given; see
+/// [`QueuedTok`].
 pub(super) struct TokenQueue<'state, 'arena> {
     lexer: Lexer<'arena>,
     pub stores: Stores<'state, 'arena>,
-    queue: VecDeque<TokSpan>,
+    queue: VecDeque<QueuedTok<'arena>>,
     lexer_is_eoi: bool,
     next_non_whitespace: usize,
+}
+
+/// A token in the queue, together with the name of the command it came from.
+///
+/// Keeping the name is what lets the body of a `\newcommand` be recorded by name rather than by
+/// the meaning those names happen to have while the body is being read; the meaning is only
+/// looked up when the command is expanded, as it is in LaTeX. The token itself is resolved all
+/// the same, because the queue is what the character class lookahead reads from.
+///
+/// The name is `None` for everything which isn't a command, for `\begin` and `\end` (whose
+/// meaning the lexer decides, so they cannot be redefined), and for the tokens which reach the
+/// queue from the body of a custom command rather than from the lexer: those carry their names
+/// as [`Token::UnresolvedCommand`] instead.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct QueuedTok<'source>(TokSpan, Option<&'source str>);
+
+#[cfg(target_arch = "wasm32")]
+static_assertions::assert_eq_size!(QueuedTok<'static>, [usize; 7]);
+
+impl<'source> QueuedTok<'source> {
+    #[inline]
+    pub(super) const fn new(tokspan: TokSpan, name: Option<&'source str>) -> Self {
+        QueuedTok(tokspan, name)
+    }
+
+    #[inline]
+    pub(super) fn token(&self) -> &Token {
+        self.0.token()
+    }
+
+    #[inline]
+    pub(super) fn tokspan(&self) -> &TokSpan {
+        &self.0
+    }
+
+    #[inline]
+    pub(super) fn into_tokspan(self) -> TokSpan {
+        self.0
+    }
+
+    #[inline]
+    pub(super) fn span(&self) -> Span {
+        self.0.span()
+    }
+
+    /// The name of the command this token came from, if it came from one.
+    #[inline]
+    pub(super) fn name(&self) -> Option<&'source str> {
+        self.1
+    }
+
+    /// Give this token a new meaning, keeping its span and the name it came from.
+    #[inline]
+    fn with_token(&self, token: Token) -> Self {
+        QueuedTok(TokSpan::new(token, self.0.span()), self.1)
+    }
+
+    /// Unwrap a [`Token::MathOrTextMode`], as [`Token::unwrap_math`] does.
+    #[inline]
+    fn unwrap_math(self) -> Self {
+        let (tok, span) = self.0.into_parts();
+        QueuedTok(TokSpan::new(tok.unwrap_math(), span), self.1)
+    }
+}
+
+impl From<Token> for QueuedTok<'_> {
+    #[inline]
+    fn from(token: Token) -> Self {
+        QueuedTok(token.into(), None)
+    }
+}
+
+impl From<TokSpan> for QueuedTok<'_> {
+    #[inline]
+    fn from(tokspan: TokSpan) -> Self {
+        QueuedTok(tokspan, None)
+    }
+}
+
+impl From<QueuedTok<'_>> for TokSpan {
+    #[inline]
+    fn from(queued: QueuedTok<'_>) -> Self {
+        queued.0
+    }
 }
 
 /// The stores which the token queue uses to resolve command names.
@@ -82,7 +169,8 @@ impl Stores<'_, '_> {
     }
 }
 
-static EOI_TOK: TokSpan = TokSpan::new(Token::Eoi, Span::zero_width(0));
+static EOI_TOK: QueuedTok<'static> =
+    QueuedTok::new(TokSpan::new(Token::Eoi, Span::zero_width(0)), None);
 
 impl<'state, 'arena> TokenQueue<'state, 'arena> {
     pub(super) fn new(
@@ -110,15 +198,16 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// Resolve the lexer output into a token.
     ///
     /// The lexer output is either a token or a command name. We look up the command name and if we
-    /// can't find it, we return an unresolved command token with an interned name.
-    fn resolve_lexed(&mut self, lexed: LexerOutput<'arena>) -> TokSpan {
+    /// can't find it, we return an unresolved command token with an interned name. Either way, the
+    /// name is kept alongside the token; see [`QueuedTok`].
+    fn resolve_lexed(&mut self, lexed: LexerOutput<'arena>) -> QueuedTok<'arena> {
         match lexed {
-            LexerOutput::Token(tokspan) => tokspan,
+            LexerOutput::Token(tokspan) => tokspan.into(),
             LexerOutput::CommandName(name, span) => {
                 let tok = self.stores.resolve_command(name).unwrap_or_else(|| {
                     Token::UnresolvedCommand(CmdSource::Local, self.stores.local_cmds.intern(name))
                 });
-                TokSpan::new(tok, span)
+                QueuedTok::new(TokSpan::new(tok, span), Some(name))
             }
         }
     }
@@ -207,10 +296,10 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
         // `next_non_whitespace` points to the next non-whitespace token,
         // or to one past the end of the buffer if there is none.
         if let Some(tok) = self.queue.get(self.next_non_whitespace) {
-            tok
+            tok.tokspan()
         } else {
             debug_assert!(self.lexer_is_eoi, "peek called without ensure");
-            &EOI_TOK
+            EOI_TOK.tokspan()
         }
     }
 
@@ -218,6 +307,12 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// and [`Token::MathOrTextMode`].
     #[inline]
     pub(super) fn peek_any_token(&self) -> &TokSpan {
+        self.peek_any_keeping_name().tokspan()
+    }
+
+    /// Same as [`Self::peek_any_token`], but keeps the name the command came from.
+    #[inline]
+    fn peek_any_keeping_name(&self) -> &QueuedTok<'arena> {
         if let Some(tok) = self.queue.front() {
             tok
         } else {
@@ -270,10 +365,10 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
             .find_or_load_after_next(is_not_whitespace)?
             .and_then(|idx| self.queue.get(idx))
         {
-            Ok(tok)
+            Ok(tok.tokspan())
         } else {
             debug_assert!(self.lexer_is_eoi, "peek_second called without ensure");
-            Ok(&EOI_TOK)
+            Ok(EOI_TOK.tokspan())
         }
     }
 
@@ -318,8 +413,13 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     ///
     /// This method also ensures that there is always a peekable token after this one.
     pub(super) fn next(&mut self) -> Result<TokSpan, Box<LatexError>> {
+        Ok(self.next_keeping_name()?.into_tokspan())
+    }
+
+    /// Same as [`Self::next`], but keeps the name the command came from.
+    pub(super) fn next_keeping_name(&mut self) -> Result<QueuedTok<'arena>, Box<LatexError>> {
         let ret = self.next_allowing_unknown_command()?;
-        self.reject_unknown_command(&ret)?;
+        self.reject_unknown_command(ret.tokspan())?;
         Ok(ret)
     }
 
@@ -328,7 +428,9 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     ///
     /// This is for the places which want to get hold of the name of a command which is
     /// not defined (yet).
-    pub(super) fn next_allowing_unknown_command(&mut self) -> Result<TokSpan, Box<LatexError>> {
+    pub(super) fn next_allowing_unknown_command(
+        &mut self,
+    ) -> Result<QueuedTok<'arena>, Box<LatexError>> {
         // Pop elements until we reach `next_non_whitespace`.
         for _ in 0..self.next_non_whitespace {
             let _ = self.queue.pop_front();
@@ -337,8 +439,7 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
         // Now pop the next token.
         if let Some(ret) = self.queue.pop_front() {
             self.ensure_next_non_whitespace()?;
-            let (tok, span) = ret.into_parts();
-            let ret = TokSpan::new(tok.unwrap_math(), span);
+            let ret = ret.unwrap_math();
             debug_assert!(!matches!(
                 ret.token(),
                 Token::Whitespace | Token::MathOrTextMode(_, _)
@@ -355,8 +456,13 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     ///
     /// This method may return whitespace tokens and [`Token::MathOrTextMode`].
     pub(super) fn next_any_token(&mut self) -> Result<TokSpan, Box<LatexError>> {
+        Ok(self.next_any_token_keeping_name()?.into_tokspan())
+    }
+
+    /// Same as [`Self::next_any_token`], but keeps the name the command came from.
+    fn next_any_token_keeping_name(&mut self) -> Result<QueuedTok<'arena>, Box<LatexError>> {
         let ret = self.next_any_token_allowing_unknown_command()?;
-        self.reject_unknown_command(&ret)?;
+        self.reject_unknown_command(ret.tokspan())?;
         Ok(ret)
     }
 
@@ -364,7 +470,7 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// as tokens instead of being rejected.
     pub(super) fn next_any_token_allowing_unknown_command(
         &mut self,
-    ) -> Result<TokSpan, Box<LatexError>> {
+    ) -> Result<QueuedTok<'arena>, Box<LatexError>> {
         if let Some(ret) = self.queue.pop_front() {
             // `next_non_whitespace` may need to be updated.
             if let Some(new_pos) = self.next_non_whitespace.checked_sub(1) {
@@ -387,7 +493,7 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// Queue a stream of tokens in the front of the buffer.
     ///
     /// We use a ring buffer, so this is efficient as long as the number of tokens is not too large.
-    pub(super) fn queue_in_front(&mut self, tokens: &[impl Into<TokSpan> + Copy]) {
+    pub(super) fn queue_in_front(&mut self, tokens: &[impl Into<QueuedTok<'arena>> + Copy]) {
         self.queue.reserve(tokens.len());
         // Queue the token stream in the front in reverse order.
         for tok in tokens.iter().rev() {
@@ -425,38 +531,42 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// simply taking the next token.
     pub(super) fn queue_body_substituting(
         &mut self,
-        tokens: &[impl Into<TokSpan> + Copy],
-        args: &CmdArgs,
+        tokens: &[impl Into<QueuedTok<'arena>> + Copy],
+        args: &CmdArgs<'arena>,
         span: Span,
     ) {
         if tokens.is_empty() {
             // A body which is empty produces nothing at all, but we still have to queue
             // something: without it, the caller would take the token which comes after the
             // command and treat that as the expansion.
-            self.queue.push_front(TokSpan::new(Token::Relax, span));
+            self.queue
+                .push_front(TokSpan::new(Token::Relax, span).into());
             self.update_next_non_whitespace();
             return;
         }
         self.queue.reserve(tokens.len());
         // Queue the token stream in the front in reverse order.
         for tok in tokens.iter().rev() {
-            let tokspan: TokSpan = (*tok).into();
-            match *tokspan.token() {
+            let queued: QueuedTok<'arena> = (*tok).into();
+            match *queued.token() {
                 Token::CustomCmdArg(arg_num) => self.push_arg_front(args.get(arg_num), span),
-                // A command which didn't exist when the body was recorded may exist by now.
+                // A command which the body only refers to by name gets its meaning here, so a
+                // command which didn't exist when the body was recorded may exist by now, and
+                // one which has been redefined since means something else now.
                 Token::UnresolvedCommand(source, name) => {
                     let resolved = self.resolve_stored(source, name);
                     // A body carries no spans of its own, so if the command is still not
                     // defined, the error has to point at the command we are expanding.
-                    let tok = resolved.unwrap_or(*tokspan.token());
+                    let tok = resolved.unwrap_or(*queued.token());
                     let tok_span = if resolved.is_some() {
-                        tokspan.span()
+                        queued.span()
                     } else {
                         span
                     };
-                    self.queue.push_front(TokSpan::new(tok, tok_span));
+                    self.queue
+                        .push_front(QueuedTok::new(TokSpan::new(tok, tok_span), queued.name()));
                 }
-                _ => self.queue.push_front(tokspan),
+                _ => self.queue.push_front(queued),
             }
         }
         self.update_next_non_whitespace();
@@ -468,20 +578,22 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// equivalent to `{}`. Substituting nothing at all would make it disappear from
     /// constructs which need an argument, which would then take whatever comes next instead.
     /// The `span` is only used for the braces of that empty group.
-    fn push_arg_front(&mut self, arg: &[TokSpan], span: Span) {
+    fn push_arg_front(&mut self, arg: &[QueuedTok<'arena>], span: Span) {
         if arg.is_empty() {
-            self.queue.push_front(TokSpan::new(Token::GroupEnd, span));
-            self.queue.push_front(TokSpan::new(Token::GroupBegin, span));
+            self.queue
+                .push_front(TokSpan::new(Token::GroupEnd, span).into());
+            self.queue
+                .push_front(TokSpan::new(Token::GroupBegin, span).into());
         } else {
-            for tokspan in arg.iter().rev() {
-                self.queue.push_front(*tokspan);
+            for queued in arg.iter().rev() {
+                self.queue.push_front(*queued);
             }
         }
     }
 
     /// Queue one argument of a custom command in the front of the buffer, as
     /// [`Self::push_arg_front`] does. Always queues at least one token.
-    pub(super) fn queue_arg_in_front(&mut self, arg: &[TokSpan], span: Span) {
+    pub(super) fn queue_arg_in_front(&mut self, arg: &[QueuedTok<'arena>], span: Span) {
         self.queue.reserve(arg.len());
         self.push_arg_front(arg, span);
         self.update_next_non_whitespace();
@@ -493,13 +605,13 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// the token of a command which is only defined once we get to it: the token right after
     /// a `\newcommand` has already been read by then.
     pub(super) fn resolve_buffered_unknown_commands(&mut self) {
-        for tokspan in &mut self.queue {
-            if let Token::UnresolvedCommand(source, name) = *tokspan.token()
+        for queued in &mut self.queue {
+            if let Token::UnresolvedCommand(source, name) = *queued.token()
                 && let Some(tok) = self
                     .stores
                     .resolve_command(self.stores.name_in_pool(source, name))
             {
-                *tokspan = TokSpan::new(tok, tokspan.span());
+                *queued = queued.with_token(tok);
             }
         }
     }
@@ -561,13 +673,11 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// The reason is the same as for [`Self::resolve_buffered_unknown_commands`]: the token
     /// after a `\renewcommand` has already been loaded, so a use of the command right after
     /// its redefinition would otherwise still refer to the old definition. We recognize the
-    /// tokens by their source text, because the old definition can be any token at all.
+    /// tokens by the name they came from, because the old definition can be any token at all.
     pub(super) fn resolve_buffered_redefined_command(&mut self, name: &str, tok: Token) {
-        let TokenQueue { lexer, queue, .. } = self;
-        for tokspan in queue.iter_mut() {
-            let span: Range<usize> = tokspan.span().into();
-            if lexer.input().get(span).and_then(|s| s.strip_prefix('\\')) == Some(name) {
-                *tokspan = TokSpan::new(tok, tokspan.span());
+        for queued in &mut self.queue {
+            if queued.name() == Some(name) {
+                *queued = queued.with_token(tok);
             }
         }
     }
@@ -579,17 +689,19 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     /// parameters have to be allowed before the token after the `{` is loaded from the lexer,
     /// and disallowed again before the token after the `}` is.
     ///
-    /// A command which isn't defined (yet) is recorded as such instead of being rejected: it
-    /// may well be defined by the time the command being defined here is used.
+    /// Every command keeps the name it came from, so that the body can be recorded by name
+    /// rather than by what those names mean right now. A command which isn't defined (yet) is
+    /// therefore recorded rather than rejected: it may well be defined by the time the command
+    /// being defined here is used.
     pub(super) fn record_macro_body(
         &mut self,
-        tokens: &mut Vec<TokSpan>,
+        tokens: &mut Vec<QueuedTok<'arena>>,
     ) -> Result<(), Box<LatexError>> {
         core::debug_assert_matches!(self.peek().token(), Token::GroupBegin);
         self.next()?; // Discard the opening `{`.
         let mut nesting_level = 0usize;
         loop {
-            let tokloc = *self.peek_any_token();
+            let tokloc = *self.peek_any_keeping_name();
             match tokloc.token() {
                 Token::GroupBegin => {
                     nesting_level += 1;
@@ -619,17 +731,17 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     ///
     /// The initial `{` must have already been consumed. The closing `}` is not included
     /// in the output token vector.
-    pub(super) fn record_group(
+    pub(super) fn record_group<T: From<QueuedTok<'arena>>>(
         &mut self,
-        tokens: &mut Vec<TokSpan>,
+        tokens: &mut Vec<T>,
         preserve_all: bool,
     ) -> Result<usize, Box<LatexError>> {
         let mut nesting_level = 0usize;
         let end = loop {
             let tokloc = if preserve_all {
-                self.next_any_token()
+                self.next_any_token_keeping_name()
             } else {
-                self.next()
+                self.next_keeping_name()
             };
             let tokloc = tokloc?;
             match tokloc.token() {
@@ -653,7 +765,7 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
                 }
                 _ => {}
             }
-            tokens.push(tokloc);
+            tokens.push(tokloc.into());
         };
         Ok(end)
     }
@@ -688,16 +800,7 @@ impl<'state, 'arena> TokenQueue<'state, 'arena> {
     ///
     /// Returns `None` if the index is out of bounds.
     pub(super) fn get_token_by_index(&self, idx: usize) -> Option<&TokSpan> {
-        self.queue.get(idx)
-    }
-
-    pub(super) fn command_name_from_span(&self, span: Span) -> Option<&str> {
-        let range: Range<usize> = span.into();
-        self.lexer
-            .input()
-            .get(range)
-            .and_then(|s| s.strip_prefix('\\'))
-            .filter(|name| is_valid_macro_name(name))
+        self.queue.get(idx).map(QueuedTok::tokspan)
     }
 }
 
@@ -716,14 +819,14 @@ fn has_class(idx: usize, tok: &Token) -> Option<(usize, Class)> {
 /// alive for as long as it takes to queue the body of the command: because the arguments are
 /// substituted into the body right away, nothing refers to them afterwards.
 #[derive(Debug, Default)]
-pub(super) struct CmdArgs {
-    tokens: Vec<TokSpan>,
+pub(super) struct CmdArgs<'source> {
+    tokens: Vec<QueuedTok<'source>>,
     offsets: [usize; 9],
 }
 
-impl CmdArgs {
+impl<'source> CmdArgs<'source> {
     /// The tokens which make up the given argument.
-    pub(super) fn get(&self, arg_num: u8) -> &[TokSpan] {
+    pub(super) fn get(&self, arg_num: u8) -> &[QueuedTok<'source>] {
         let start = self
             .offsets
             .get(arg_num.wrapping_sub(1) as usize)
@@ -744,8 +847,8 @@ impl CmdArgs {
     }
 
     /// Append a token to the argument which is currently being read.
-    pub(super) fn push(&mut self, tokspan: TokSpan) {
-        self.tokens.push(tokspan);
+    pub(super) fn push(&mut self, queued: QueuedTok<'source>) {
+        self.tokens.push(queued);
     }
 
     /// Mark the end of the argument with the given index.
@@ -756,7 +859,7 @@ impl CmdArgs {
     }
 
     /// The buffer to read the tokens of an argument into.
-    pub(super) fn buffer(&mut self) -> &mut Vec<TokSpan> {
+    pub(super) fn buffer(&mut self) -> &mut Vec<QueuedTok<'source>> {
         &mut self.tokens
     }
 }
@@ -853,7 +956,7 @@ mod tests {
             manager.load_token_skip_whitespace().unwrap();
             // Check that the first token is `GroupBegin`.
             std::assert_matches!(manager.next().unwrap().token(), Token::GroupBegin);
-            let mut tokens = Vec::new();
+            let mut tokens: Vec<TokSpan> = Vec::new();
             let tokens = match manager.record_group(&mut tokens, true) {
                 Ok(_) => {
                     let mut token_str = String::new();

--- a/crates/math-core/tests/custom_cmd_test.rs
+++ b/crates/math-core/tests/custom_cmd_test.rs
@@ -318,17 +318,11 @@ fn test_renewcommand() {
             "renewcommand_replaces_builtin_with_args",
             r"\renewcommand{\frac}[2]{#1/#2}\frac{1}{2}",
         ),
-        // The old definition is still in place inside the body of the new one, so this
-        // doesn't recurse (in LaTeX, it would).
+        // A body refers to the names it mentions, not to what they meant when it was
+        // recorded, so redefining a command does change the commands which use it, as it
+        // does in LaTeX.
         (
-            "renewcommand_body_uses_old_definition",
-            r"\newcommand{\zz}{\mathbb{Z}}\renewcommand{\zz}{(\zz)}\zz",
-        ),
-        // A body refers to the definition which was in place when it was recorded, so
-        // redefining a command doesn't change the commands which use it. LaTeX, which
-        // resolves names at expansion time, gives `2` here.
-        (
-            "renewcommand_does_not_affect_earlier_body",
+            "renewcommand_affects_earlier_body",
             r"\newcommand{\xx}{1}\newcommand{\yy}{\xx}\renewcommand{\xx}{2}\yy",
         ),
         // After a `\renewcommand`, `\providecommand` still finds the name taken.
@@ -336,12 +330,94 @@ fn test_renewcommand() {
             "renewcommand_then_providecommand",
             r"\renewcommand{\epsilon}{a}\providecommand{\epsilon}{b}\epsilon",
         ),
+        // Redefining a command in terms of a command which is *not* the one being redefined
+        // is not recursion, even when the two look alike.
+        (
+            "renewcommand_body_uses_other_command",
+            r"\newcommand{\zz}{\mathbb{Z}}\renewcommand{\zz}{(\mathbb{Z})}\zz",
+        ),
     ] {
         let mathml = converter
             .convert_with_local_state(latex, MathDisplay::Inline)
             .unwrap_or_else(|e| panic!("failed to convert `{latex}` with error '{e}'"));
         assert_snapshot!(name, mathml.mathml, latex);
     }
+}
+
+/// A command in the body of a `\newcommand` is recorded by name, so it means whatever that
+/// name means when the command is expanded, the way it does in LaTeX. This is what config
+/// macros have always done; these are the cases where a document definition used to differ.
+#[test]
+fn test_late_resolution() {
+    let config = MathCoreConfig {
+        pretty_print: PrettyPrint::Always,
+        ..Default::default()
+    };
+    let converter = LatexToMathML::new(config).unwrap();
+
+    for (name, latex) in [
+        // A builtin which is redefined after the body was recorded.
+        (
+            "late_resolution_of_builtin",
+            r"\newcommand{\foo}{\epsilon}\renewcommand{\epsilon}{e}\foo",
+        ),
+        // The same, with neither name in braces.
+        (
+            "late_resolution_unbraced_name",
+            r"\newcommand\foo{\epsilon}\renewcommand\epsilon{e}\foo",
+        ),
+        // A body which isn't a group consists of a single token, which is recorded by name
+        // just like the tokens of a group are.
+        (
+            "late_resolution_unbraced_body",
+            r"\newcommand\foo\epsilon\renewcommand\epsilon{e}\foo",
+        ),
+        // The definition is assembled out of the argument of another command, so its body
+        // reaches the queue by substitution rather than straight from the lexer.
+        (
+            "late_resolution_through_argument",
+            r"\newcommand{\m}[1]{x#1}\newcommand{\a}{1}\newcommand{\z}{0}\m{\renewcommand{\z}{\a}}\renewcommand{\a}{2}\z",
+        ),
+        // `\begin` and `\end` get their meaning in the lexer, which consumes the environment
+        // name along with them, so they have no name to be recorded under. `\\` does.
+        (
+            "late_resolution_env_in_body",
+            r"\newcommand{\m}{\begin{matrix}a\\b\end{matrix}}\m",
+        ),
+        // Two commands with an empty body mean the same thing without being the same command.
+        (
+            "late_resolution_empty_bodies",
+            r"\newcommand{\p}{}\newcommand{\q}{}\newcommand{\pq}{a\p b\q c}\renewcommand{\q}{!}\pq",
+        ),
+    ] {
+        let mathml = converter
+            .convert_with_local_state(latex, MathDisplay::Inline)
+            .unwrap_or_else(|e| panic!("failed to convert `{latex}` with error '{e}'"));
+        assert_snapshot!(name, mathml.mathml, latex);
+    }
+}
+
+/// The same, across snippets: the name a body refers to has to outlive the snippet which
+/// recorded it, and the redefinition which it picks up comes from a later snippet.
+#[test]
+fn test_late_resolution_across_snippets() {
+    let config = MathCoreConfig {
+        pretty_print: PrettyPrint::Always,
+        global_group: true,
+        ..Default::default()
+    };
+    let mut converter = LatexToMathML::new(config).unwrap();
+
+    converter
+        .convert_with_global_state(r"\newcommand{\foo}{\epsilon}", MathDisplay::Inline)
+        .unwrap();
+    converter
+        .convert_with_global_state(r"\renewcommand{\epsilon}{e}", MathDisplay::Inline)
+        .unwrap();
+    let mathml = converter
+        .convert_with_global_state(r"\foo", MathDisplay::Inline)
+        .unwrap();
+    assert_snapshot!("late_resolution_across_snippets", mathml.mathml, r"\foo");
 }
 
 #[test]
@@ -432,6 +508,9 @@ fn test_expansion_limit() {
         r"\newcommand{\a}{\b}\newcommand{\b}{\a}\a",
         // A command which expands to itself.
         r"\newcommand{\a}{x\a}\a",
+        // A `\renewcommand` whose body mentions the command being redefined. The body refers
+        // to the new definition, not to the old one, so this recurses, as it does in LaTeX.
+        r"\newcommand{\zz}{\mathbb{Z}}\renewcommand{\zz}{(\zz)}\zz",
     ] {
         let Err(err) = converter.convert_with_local_state(latex, MathDisplay::Inline) else {
             panic!("`{latex}` should not have converted");

--- a/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_across_snippets.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_across_snippets.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/custom_cmd_test.rs
+expression: "\\foo"
+---
+<math>
+    <mi>e</mi>
+</math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_empty_bodies.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_empty_bodies.snap
@@ -1,0 +1,11 @@
+---
+source: crates/math-core/tests/custom_cmd_test.rs
+expression: "\\newcommand{\\p}{}\\newcommand{\\q}{}\\newcommand{\\pq}{a\\p b\\q c}\\renewcommand{\\q}{!}\\pq"
+---
+<math>
+    <mi>a</mi>
+    <mrow></mrow>
+    <mi>b</mi>
+    <mo form="postfix">!</mo>
+    <mi>c</mi>
+</math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_env_in_body.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_env_in_body.snap
@@ -1,0 +1,18 @@
+---
+source: crates/math-core/tests/custom_cmd_test.rs
+expression: "\\newcommand{\\m}{\\begin{matrix}a\\\\b\\end{matrix}}\\m"
+---
+<math>
+    <mtable displaystyle="false" scriptlevel="0">
+        <mtr>
+            <mtd>
+                <mi>a</mi>
+            </mtd>
+        </mtr>
+        <mtr>
+            <mtd>
+                <mi>b</mi>
+            </mtd>
+        </mtr>
+    </mtable>
+</math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_of_builtin.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_of_builtin.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/custom_cmd_test.rs
+expression: "\\newcommand{\\foo}{\\epsilon}\\renewcommand{\\epsilon}{e}\\foo"
+---
+<math>
+    <mi>e</mi>
+</math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_through_argument.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_through_argument.snap
@@ -1,0 +1,8 @@
+---
+source: crates/math-core/tests/custom_cmd_test.rs
+expression: "\\newcommand{\\m}[1]{x#1}\\newcommand{\\a}{1}\\newcommand{\\z}{0}\\m{\\renewcommand{\\z}{\\a}}\\renewcommand{\\a}{2}\\z"
+---
+<math>
+    <mi>x</mi>
+    <mn>2</mn>
+</math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_unbraced_body.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_unbraced_body.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/custom_cmd_test.rs
+expression: "\\newcommand\\foo\\epsilon\\renewcommand\\epsilon{e}\\foo"
+---
+<math>
+    <mi>e</mi>
+</math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_unbraced_name.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__late_resolution_unbraced_name.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/custom_cmd_test.rs
+expression: "\\newcommand\\foo{\\epsilon}\\renewcommand\\epsilon{e}\\foo"
+---
+<math>
+    <mi>e</mi>
+</math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__renewcommand_affects_earlier_body.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__renewcommand_affects_earlier_body.snap
@@ -3,5 +3,5 @@ source: crates/math-core/tests/custom_cmd_test.rs
 expression: "\\newcommand{\\xx}{1}\\newcommand{\\yy}{\\xx}\\renewcommand{\\xx}{2}\\yy"
 ---
 <math>
-    <mn>1</mn>
+    <mn>2</mn>
 </math>

--- a/crates/math-core/tests/snapshots/custom_cmd_test__renewcommand_body_uses_other_command.snap
+++ b/crates/math-core/tests/snapshots/custom_cmd_test__renewcommand_body_uses_other_command.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/math-core/tests/custom_cmd_test.rs
-expression: "\\newcommand{\\zz}{\\mathbb{Z}}\\renewcommand{\\zz}{(\\zz)}\\zz"
+expression: "\\newcommand{\\zz}{\\mathbb{Z}}\\renewcommand{\\zz}{(\\mathbb{Z})}\\zz"
 ---
 <math>
     <mo stretchy="false">(</mo>


### PR DESCRIPTION
The following works now

```tex
\newcommand\foo{\epsilon}
\renewcommand\epsilon{e}
\foo
```