### PR TITLE
Implement `\raisebox{length}{text}`

### DIFF
--- a/crates/math-core/src/commands.rs
+++ b/crates/math-core/src/commands.rs
@@ -689,6 +689,7 @@ static COMMANDS: phf::Map<&'static str, Token> = phf::phf_map! {
     "rArr" => Relation(symbol::RIGHTWARDS_DOUBLE_ARROW),
     "rBrace" => Close(symbol::RIGHT_WHITE_CURLY_BRACKET),
     "rVert" => Close(symbol::DOUBLE_VERTICAL_LINE),
+    "raisebox" => RaiseBox,
     "rang" => Close(symbol::MATHEMATICAL_RIGHT_ANGLE_BRACKET),
     "rangle" => Close(symbol::MATHEMATICAL_RIGHT_ANGLE_BRACKET),
     "rarr" => Relation(symbol::RIGHTWARDS_ARROW),

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -786,6 +786,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                         height_0: false,
                         left,
                         right,
+                        voffset: None,
                     }),
                 }
             }
@@ -852,7 +853,6 @@ impl<'state, 'arena> Parser<'state, 'arena> {
             Token::NonBreakingSpace => Ok(Node::Text {
                 text_style: None,
                 text_size: None,
-                text_voffset: None,
                 text: "\u{A0}",
             }),
             Token::Sqrt => {
@@ -1580,14 +1580,26 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let nodes = snippets
                     .into_iter()
                     .map(|TextSnippet(text_style, text_size, text_voffset, text)| {
-                        let text_voffset = text_voffset
-                            .as_ref()
-                            .map(|tv| self.arena.alloc_length_set(*tv));
-                        self.commit(Node::Text {
+                        let text_node = Node::Text {
                             text_style,
                             text_size,
-                            text_voffset,
                             text,
+                        };
+                        let voffset = text_voffset
+                            .as_ref()
+                            .filter(|voffset| **voffset != LengthSet::zero())
+                            .map(|tv| self.arena.alloc_length_set(*tv));
+                        self.commit(if voffset.is_some() {
+                            Node::Padded {
+                                node: self.commit(text_node),
+                                width_0: false,
+                                height_0: false,
+                                left: None,
+                                right: None,
+                                voffset,
+                            }
+                        } else {
+                            text_node
                         })
                     })
                     .collect::<Vec<_>>();
@@ -1622,13 +1634,26 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let nodes = snippets
                     .into_iter()
                     .map(|TextSnippet(text_style, text_size, text_voffset, text)| {
-                        self.commit(Node::Text {
+                        let voffset = text_voffset
+                            .filter(|voffset| *voffset != LengthSet::zero())
+                            .as_ref()
+                            .map(|tv| self.arena.alloc_length_set(*tv));
+                        let text_node = Node::Text {
                             text_style,
                             text_size,
-                            text_voffset: text_voffset
-                                .as_ref()
-                                .map(|tv| self.arena.alloc_length_set(*tv)),
                             text,
+                        };
+                        self.commit(if voffset.is_some() {
+                            Node::Padded {
+                                node: self.commit(text_node),
+                                width_0: false,
+                                height_0: false,
+                                left: None,
+                                right: None,
+                                voffset,
+                            }
+                        } else {
+                            text_node
                         })
                     })
                     .collect::<Vec<_>>();
@@ -1928,6 +1953,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                         height_0: true,
                         left: None,
                         right: None,
+                        voffset: None,
                     }),
                     PhantomKind::V => Ok(Node::Padded {
                         node: self.arena.push(Node::Phantom { node: inner }),
@@ -1935,6 +1961,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                         height_0: false,
                         left: None,
                         right: None,
+                        voffset: None,
                     }),
                 }
             }

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -8,7 +8,7 @@ use mathml_renderer::{
     arena::{Arena, Buffer},
     ast::{MultiscriptPair, Node},
     attribute::{FracAttr, LetterAttr, MathSpacing, OpAttrs, RowAttrs, Style},
-    length::{Length, LengthUnit},
+    length::{Length, LengthSet, LengthUnit},
     super_char::SuperChar,
     symbol::{self, OpCategory, OrdCategory, OrdLike, RelCategory},
     table::{EquationTag, LineType, RowLabelInfo},
@@ -849,7 +849,12 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 class = prev_class;
                 Ok(self.parse_kern_or_skip(kind, span.end())?)
             }
-            Token::NonBreakingSpace => Ok(Node::Text(None, None, "\u{A0}")),
+            Token::NonBreakingSpace => Ok(Node::Text {
+                text_style: None,
+                text_size: None,
+                text_voffset: None,
+                text: "\u{A0}",
+            }),
             Token::Sqrt => {
                 let next = self.next_token();
                 if let Ok(tokloc) = next
@@ -1546,9 +1551,9 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 ))
             }
             Token::OperatorName { with_limits } => {
-                let snippets = self.extract_text(None, false)?;
+                let snippets = self.extract_text(None, None, false)?;
                 let mut builder = self.buffer.get_builder();
-                for TextSnippet(_style, _size, text) in snippets {
+                for TextSnippet(_style, _size, _voffset, text) in snippets {
                     builder.push_str(text);
                 }
                 let letters = builder.finish(self.arena);
@@ -1571,11 +1576,55 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 }
             }
             Token::Text(transform) => {
-                let snippets = self.extract_text(transform, true)?;
+                let snippets = self.extract_text(transform, None, true)?;
                 let nodes = snippets
                     .into_iter()
-                    .map(|TextSnippet(style, size, text)| {
-                        self.commit(Node::Text(style, size, text))
+                    .map(|TextSnippet(text_style, text_size, text_voffset, text)| {
+                        self.commit(Node::Text {
+                            text_style,
+                            text_size,
+                            text_voffset,
+                            text,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                return Ok(Parsed::Node(
+                    Class::Close,
+                    node_vec_to_node(self.arena, &nodes, false),
+                ));
+            }
+            Token::RaiseBox => {
+                let (initial_voffset_str, span) = self.parse_string_literal()?;
+                let initial_voffset = match parse_length_specification(initial_voffset_str) {
+                    Some((voffset, unit, is_math_unit)) => {
+                        if is_math_unit {
+                            return Err(Box::new(LatexError(
+                                span,
+                                LatexErrKind::IllegalUnit {
+                                    unit: unit.into(),
+                                    math_unit_expected: false,
+                                },
+                            )));
+                        }
+                        LengthSet::from(voffset)
+                    }
+                    None => {
+                        return Err(Box::new(LatexError(
+                            span,
+                            LatexErrKind::ExpectedLength(initial_voffset_str.into()),
+                        )));
+                    }
+                };
+                let snippets = self.extract_text(None, Some(initial_voffset), true)?;
+                let nodes = snippets
+                    .into_iter()
+                    .map(|TextSnippet(text_style, text_size, text_voffset, text)| {
+                        self.commit(Node::Text {
+                            text_style,
+                            text_size,
+                            text_voffset,
+                            text,
+                        })
                     })
                     .collect::<Vec<_>>();
                 return Ok(Parsed::Node(

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -1580,6 +1580,9 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let nodes = snippets
                     .into_iter()
                     .map(|TextSnippet(text_style, text_size, text_voffset, text)| {
+                        let text_voffset = text_voffset
+                            .as_ref()
+                            .map(|tv| self.arena.alloc_length_set(*tv));
                         self.commit(Node::Text {
                             text_style,
                             text_size,
@@ -1622,7 +1625,9 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                         self.commit(Node::Text {
                             text_style,
                             text_size,
-                            text_voffset,
+                            text_voffset: text_voffset
+                                .as_ref()
+                                .map(|tv| self.arena.alloc_length_set(*tv)),
                             text,
                         })
                     })

--- a/crates/math-core/src/snapshots/math_core__parser__tests__comment.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__comment.snap
@@ -3,5 +3,10 @@ source: crates/math-core/src/parser.rs
 expression: "\\text{% comment}\n\\%as}"
 ---
 [
-  Text(None, None, "%as"),
+  Text(
+    text_style: None,
+    text_size: None,
+    text_voffset: None,
+    text: "%as",
+  ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__comment.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__comment.snap
@@ -6,7 +6,6 @@ expression: "\\text{% comment}\n\\%as}"
   Text(
     text_style: None,
     text_size: None,
-    text_voffset: None,
     text: "%as",
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathstrut.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathstrut.snap
@@ -17,5 +17,6 @@ expression: "\\mathstrut"
     height_0: false,
     left: None,
     right: None,
+    voffset: None,
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__number_with_spaces_in_text.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__number_with_spaces_in_text.snap
@@ -6,7 +6,6 @@ expression: "\\text{1 2  3    4}"
   Text(
     text_style: None,
     text_size: None,
-    text_voffset: None,
     text: "1\u{a0}2\u{a0}3\u{a0}4",
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__number_with_spaces_in_text.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__number_with_spaces_in_text.snap
@@ -3,5 +3,10 @@ source: crates/math-core/src/parser.rs
 expression: "\\text{1 2  3    4}"
 ---
 [
-  Text(None, None, "1\u{a0}2\u{a0}3\u{a0}4"),
+  Text(
+    text_style: None,
+    text_size: None,
+    text_voffset: None,
+    text: "1\u{a0}2\u{a0}3\u{a0}4",
+  ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal.snap
@@ -3,5 +3,10 @@ source: crates/math-core/src/parser.rs
 expression: "[Text(None), InternalStringLiteral(\"hi\")]"
 ---
 [
-  Text(None, None, "hi"),
+  Text(
+    text_style: None,
+    text_size: None,
+    text_voffset: None,
+    text: "hi",
+  ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal.snap
@@ -6,7 +6,6 @@ expression: "[Text(None), InternalStringLiteral(\"hi\")]"
   Text(
     text_style: None,
     text_size: None,
-    text_voffset: None,
     text: "hi",
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal_and_other.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal_and_other.snap
@@ -3,5 +3,10 @@ source: crates/math-core/src/parser.rs
 expression: "[Text(None), GroupBegin, Letter(\"a\", MathOrText), InternalStringLiteral(\"hi\"), GroupEnd]"
 ---
 [
-  Text(None, None, "ahi"),
+  Text(
+    text_style: None,
+    text_size: None,
+    text_voffset: None,
+    text: "ahi",
+  ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal_and_other.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__text_internal_string_literal_and_other.snap
@@ -6,7 +6,6 @@ expression: "[Text(None), GroupBegin, Letter(\"a\", MathOrText), InternalStringL
   Text(
     text_style: None,
     text_size: None,
-    text_voffset: None,
     text: "ahi",
   ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__text_number.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__text_number.snap
@@ -6,7 +6,6 @@ expression: "\\text123"
   Text(
     text_style: None,
     text_size: None,
-    text_voffset: None,
     text: "1",
   ),
   Number("23"),

--- a/crates/math-core/src/snapshots/math_core__parser__tests__text_number.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__text_number.snap
@@ -3,6 +3,11 @@ source: crates/math-core/src/parser.rs
 expression: "\\text123"
 ---
 [
-  Text(None, None, "1"),
+  Text(
+    text_style: None,
+    text_size: None,
+    text_voffset: None,
+    text: "1",
+  ),
   Number("23"),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__textbf.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__textbf.snap
@@ -3,5 +3,10 @@ source: crates/math-core/src/parser.rs
 expression: "\\textbf{abc}"
 ---
 [
-  Text(Some(Bold), None, "abc"),
+  Text(
+    text_style: Some(Bold),
+    text_size: None,
+    text_voffset: None,
+    text: "abc",
+  ),
 ]

--- a/crates/math-core/src/snapshots/math_core__parser__tests__textbf.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__textbf.snap
@@ -6,7 +6,6 @@ expression: "\\textbf{abc}"
   Text(
     text_style: Some(Bold),
     text_size: None,
-    text_voffset: None,
     text: "abc",
   ),
 ]

--- a/crates/math-core/src/text_parser.rs
+++ b/crates/math-core/src/text_parser.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use mathml_renderer::{
     arena::StringBuilder,
     attribute::{HtmlTextSize, HtmlTextStyle},
-    length::{Length, LengthUnit},
+    length::{Length, LengthSet, LengthUnit},
     super_char::SuperChar,
     symbol,
 };
@@ -13,7 +13,7 @@ use mathml_renderer::{
 use crate::{
     error::{LatexErrKind, LatexError},
     parser::{ParseResult, Parser},
-    specifications::LatexUnit,
+    specifications::{LatexUnit, parse_length_specification},
     token::{EndToken, Mode, TextToken, Token},
 };
 
@@ -21,6 +21,7 @@ use crate::{
 pub(super) struct TextSnippet<'arena>(
     pub Option<HtmlTextStyle>,
     pub Option<HtmlTextSize>,
+    pub Option<LengthSet>,
     pub &'arena str,
 );
 
@@ -28,9 +29,10 @@ impl<'arena> Parser<'_, 'arena> {
     pub(super) fn extract_text(
         &mut self,
         initial_style: Option<HtmlTextStyle>,
+        initial_voffset: Option<LengthSet>,
         text_mode: bool,
     ) -> ParseResult<Vec<TextSnippet<'arena>>> {
-        let mut style_stack = vec![(0usize, initial_style)];
+        let mut style_stack = vec![(0usize, initial_style, initial_voffset)];
         let mut str_builder: Option<StringBuilder> = None;
         let mut snippets: Vec<TextSnippet<'arena>> = Vec::new();
         let mut accent_to_insert: Option<char> = None;
@@ -41,7 +43,9 @@ impl<'arena> Parser<'_, 'arena> {
         // reset on every style push, so the nesting level alone would be ambiguous.)
         let mut size_stack: Vec<(usize, usize, HtmlTextSize)> = Vec::new();
 
-        while let Some((previous_nesting, current_style)) = style_stack.last().copied() {
+        while let Some((previous_nesting, current_style, current_voffset)) =
+            style_stack.last().copied()
+        {
             let current_size = size_stack.last().map(|&(_, _, size)| size);
             let tokloc = if text_mode {
                 self.tokens.next_any_token()
@@ -74,9 +78,14 @@ impl<'arena> Parser<'_, 'arena> {
                                 && !builder.is_empty()
                             {
                                 let text = builder.finish(self.arena);
-                                snippets.push(TextSnippet(current_style, current_size, text));
+                                snippets.push(TextSnippet(
+                                    current_style,
+                                    current_size,
+                                    current_voffset,
+                                    text,
+                                ));
                             }
-                            style_stack.push((brace_nesting, Some(style)));
+                            style_stack.push((brace_nesting, Some(style), current_voffset));
                             brace_nesting = 0;
                             continue;
                         }
@@ -86,7 +95,12 @@ impl<'arena> Parser<'_, 'arena> {
                                     str_builder = Some(builder);
                                 } else {
                                     let text = builder.finish(self.arena);
-                                    snippets.push(TextSnippet(current_style, current_size, text));
+                                    snippets.push(TextSnippet(
+                                        current_style,
+                                        current_size,
+                                        current_voffset,
+                                        text,
+                                    ));
                                     str_builder = Some(self.buffer.get_builder());
                                 }
                                 size_stack.push((style_stack.len(), brace_nesting, text_size));
@@ -127,6 +141,7 @@ impl<'arena> Parser<'_, 'arena> {
                     | Token::Text(_)
                     | Token::Eoi
                     | Token::Right
+                    | Token::RaiseBox
                     | Token::End(_)
             ) {
                 // These tokens are valid in both math and text mode.
@@ -147,7 +162,12 @@ impl<'arena> Parser<'_, 'arena> {
                             str_builder.push_str(output);
                             continue;
                         } else {
-                            snippets.push(TextSnippet(current_style, current_size, output));
+                            snippets.push(TextSnippet(
+                                current_style,
+                                current_size,
+                                current_voffset,
+                                output,
+                            ));
                             style_stack.pop();
                             brace_nesting = previous_nesting;
                             discard_dead_sizes(&mut size_stack, style_stack.len(), brace_nesting);
@@ -183,6 +203,7 @@ impl<'arena> Parser<'_, 'arena> {
                                         snippets.push(TextSnippet(
                                             current_style,
                                             current_size,
+                                            current_voffset,
                                             text,
                                         ));
                                     }
@@ -200,7 +221,12 @@ impl<'arena> Parser<'_, 'arena> {
                             } else {
                                 if !builder.is_empty() {
                                     let text = builder.finish(self.arena);
-                                    snippets.push(TextSnippet(current_style, current_size, text));
+                                    snippets.push(TextSnippet(
+                                        current_style,
+                                        current_size,
+                                        current_voffset,
+                                        text,
+                                    ));
                                 }
                                 style_stack.pop();
                                 brace_nesting = previous_nesting;
@@ -224,7 +250,12 @@ impl<'arena> Parser<'_, 'arena> {
                             && !builder.is_empty()
                         {
                             let text = builder.finish(self.arena);
-                            snippets.push(TextSnippet(current_style, current_size, text));
+                            snippets.push(TextSnippet(
+                                current_style,
+                                current_size,
+                                current_voffset,
+                                text,
+                            ));
                         }
                         let new_style = match (current_style, style) {
                             (Some(HtmlTextStyle::Emphasis), Some(HtmlTextStyle::Emphasis)) => None,
@@ -234,8 +265,53 @@ impl<'arena> Parser<'_, 'arena> {
                             }
                             _ => style,
                         };
-                        style_stack.push((brace_nesting, new_style));
+                        style_stack.push((brace_nesting, new_style, current_voffset));
                         brace_nesting = 0;
+                        continue;
+                    }
+                    Token::RaiseBox => {
+                        if let Some(builder) = str_builder
+                            && !builder.is_empty()
+                        {
+                            let text = builder.finish(self.arena);
+                            snippets.push(TextSnippet(
+                                current_style,
+                                current_size,
+                                current_voffset,
+                                text,
+                            ));
+                        }
+
+                        let (voffset_str, span) = self.parse_string_literal()?;
+                        let new_voffset = match parse_length_specification(voffset_str) {
+                            Some((voffset, unit, is_math_unit)) => {
+                                if is_math_unit {
+                                    return Err(Box::new(LatexError(
+                                        span,
+                                        LatexErrKind::IllegalUnit {
+                                            unit: unit.into(),
+                                            math_unit_expected: false,
+                                        },
+                                    )));
+                                }
+                                LengthSet::from(voffset)
+                            }
+                            None => {
+                                return Err(Box::new(LatexError(
+                                    span,
+                                    LatexErrKind::ExpectedLength(voffset_str.into()),
+                                )));
+                            }
+                        };
+
+                        let voffset = match current_voffset {
+                            Some(current_voffset) => current_voffset + new_voffset,
+                            None => new_voffset,
+                        };
+
+                        style_stack.push((brace_nesting, current_style, Some(voffset)));
+                        brace_nesting = 0;
+                        str_builder = None;
                         continue;
                     }
                     Token::Eoi => {
@@ -265,7 +341,12 @@ impl<'arena> Parser<'_, 'arena> {
                             str_builder.push_str(output);
                             continue;
                         }
-                        snippets.push(TextSnippet(current_style, current_size, output));
+                        snippets.push(TextSnippet(
+                            current_style,
+                            current_size,
+                            current_voffset,
+                            output,
+                        ));
                         style_stack.pop();
                         brace_nesting = previous_nesting;
                         discard_dead_sizes(&mut size_stack, style_stack.len(), brace_nesting);
@@ -320,7 +401,12 @@ impl<'arena> Parser<'_, 'arena> {
             } else {
                 let mut b = [0u8; SuperChar::MAX_LEN_UTF8];
                 let text = self.arena.alloc_str(c.encode_utf8(&mut b));
-                snippets.push(TextSnippet(current_style, current_size, text));
+                snippets.push(TextSnippet(
+                    current_style,
+                    current_size,
+                    current_voffset,
+                    text,
+                ));
                 style_stack.pop();
                 brace_nesting = previous_nesting;
                 discard_dead_sizes(&mut size_stack, style_stack.len(), brace_nesting);

--- a/crates/math-core/src/token.rs
+++ b/crates/math-core/src/token.rs
@@ -240,6 +240,8 @@ pub enum Token {
     /// the parser state. Besides the command itself, this is what a custom command with an
     /// empty body expands to, so that such a command still has a token to expand to.
     Relax,
+    /// `\raisebox{length}{text}` produces a text block with a vertical offset.
+    RaiseBox,
     /// `\mathchoice{display}{text}{script}{scriptscript}`, which expands to whichever of its
     /// four arguments matches the style which is current where the command appears.
     /// Unlike in LaTeX, the three other arguments are not typeset at all.
@@ -626,6 +628,7 @@ impl Token {
             | Prime(_)
             | Enclose(_)
             | Text(_)
+            | RaiseBox
             | Style(_)
             | Cramped
             | Color

--- a/crates/math-core/tests/conversion_test.rs
+++ b/crates/math-core/tests/conversion_test.rs
@@ -808,6 +808,28 @@ fn main() {
         ("big_set_class_lookahead", r"\Set{ = | x }"),
         ("set_class_lookahead", r"\set{ = | x }"),
         ("big_braket_class_lookahead", r"\Braket{=|x}"),
+        ("raisebox_basic", r"\raisebox{1em}{foobar}"),
+        ("raisebox_negative", r"\raisebox{-1em}{foobar}"),
+        (
+            "raisebox_stack_same",
+            r"\raisebox{1em}{\raisebox{1em}{foobar}}",
+        ),
+        (
+            "raisebox_stack_different",
+            r"\raisebox{1em}{\raisebox{1pt}{foobar}}",
+        ),
+        (
+            "raisebox_multi",
+            r"\raisebox{1em}{foo{\raisebox{1pt}{bar}}}",
+        ),
+        (
+            "raisebox_multi_same",
+            r"\raisebox{1em}{foo{\raisebox{1em}{bar}}}",
+        ),
+        (
+            "raisebox_multi_cancel",
+            r"\raisebox{1em}{foo{\raisebox{-1em}{bar}}}",
+        ),
     ];
 
     let config = MathCoreConfig {

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_basic.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_basic.snap
@@ -3,5 +3,7 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\raisebox{1em}{foobar}"
 ---
 <math>
-    <mpadded voffset="1em"><mtext>foobar</mtext></mpadded>
+    <mpadded voffset="1em">
+        <mtext>foobar</mtext>
+    </mpadded>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_basic.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_basic.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\raisebox{1em}{foobar}"
+---
+<math>
+    <mpadded voffset="1em"><mtext>foobar</mtext></mpadded>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_multi.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_multi.snap
@@ -4,7 +4,11 @@ expression: "\\raisebox{1em}{foo{\\raisebox{1pt}{bar}}}"
 ---
 <math>
     <mrow>
-        <mpadded voffset="1em"><mtext>foo</mtext></mpadded>
-        <mpadded voffset="0.1rem"><mpadded voffset="1em"><mtext>bar</mtext></mpadded></mpadded>
+        <mpadded voffset="1em">
+            <mtext>foo</mtext>
+        </mpadded>
+        <mpadded voffset="0.1rem"><mpadded voffset="1em">
+            <mtext>bar</mtext>
+        </mpadded></mpadded>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_multi.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_multi.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\raisebox{1em}{foo{\\raisebox{1pt}{bar}}}"
+---
+<math>
+    <mrow>
+        <mpadded voffset="1em"><mtext>foo</mtext></mpadded>
+        <mpadded voffset="0.1rem"><mpadded voffset="1em"><mtext>bar</mtext></mpadded></mpadded>
+    </mrow>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_cancel.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_cancel.snap
@@ -4,7 +4,9 @@ expression: "\\raisebox{1em}{foo{\\raisebox{-1em}{bar}}}"
 ---
 <math>
     <mrow>
-        <mpadded voffset="1em"><mtext>foo</mtext></mpadded>
+        <mpadded voffset="1em">
+            <mtext>foo</mtext>
+        </mpadded>
         <mtext>bar</mtext>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_cancel.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_cancel.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\raisebox{1em}{foo{\\raisebox{-1em}{bar}}}"
+---
+<math>
+    <mrow>
+        <mpadded voffset="1em"><mtext>foo</mtext></mpadded>
+        <mtext>bar</mtext>
+    </mrow>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_same.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_same.snap
@@ -4,7 +4,11 @@ expression: "\\raisebox{1em}{foo{\\raisebox{1em}{bar}}}"
 ---
 <math>
     <mrow>
-        <mpadded voffset="1em"><mtext>foo</mtext></mpadded>
-        <mpadded voffset="2em"><mtext>bar</mtext></mpadded>
+        <mpadded voffset="1em">
+            <mtext>foo</mtext>
+        </mpadded>
+        <mpadded voffset="2em">
+            <mtext>bar</mtext>
+        </mpadded>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_same.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_multi_same.snap
@@ -1,0 +1,10 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\raisebox{1em}{foo{\\raisebox{1em}{bar}}}"
+---
+<math>
+    <mrow>
+        <mpadded voffset="1em"><mtext>foo</mtext></mpadded>
+        <mpadded voffset="2em"><mtext>bar</mtext></mpadded>
+    </mrow>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_negative.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_negative.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\raisebox{-1em}{foobar}"
+---
+<math>
+    <mpadded voffset="-1em"><mtext>foobar</mtext></mpadded>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_negative.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_negative.snap
@@ -3,5 +3,7 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\raisebox{-1em}{foobar}"
 ---
 <math>
-    <mpadded voffset="-1em"><mtext>foobar</mtext></mpadded>
+    <mpadded voffset="-1em">
+        <mtext>foobar</mtext>
+    </mpadded>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_different.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_different.snap
@@ -3,5 +3,7 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\raisebox{1em}{\\raisebox{1pt}{foobar}}"
 ---
 <math>
-    <mpadded voffset="0.1rem"><mpadded voffset="1em"><mtext>foobar</mtext></mpadded></mpadded>
+    <mpadded voffset="0.1rem"><mpadded voffset="1em">
+        <mtext>foobar</mtext>
+    </mpadded></mpadded>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_different.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_different.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\raisebox{1em}{\\raisebox{1pt}{foobar}}"
+---
+<math>
+    <mpadded voffset="0.1rem"><mpadded voffset="1em"><mtext>foobar</mtext></mpadded></mpadded>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_same.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_same.snap
@@ -1,0 +1,7 @@
+---
+source: crates/math-core/tests/conversion_test.rs
+expression: "\\raisebox{1em}{\\raisebox{1em}{foobar}}"
+---
+<math>
+    <mpadded voffset="2em"><mtext>foobar</mtext></mpadded>
+</math>

--- a/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_same.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__raisebox_stack_same.snap
@@ -3,5 +3,7 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\raisebox{1em}{\\raisebox{1em}{foobar}}"
 ---
 <math>
-    <mpadded voffset="2em"><mtext>foobar</mtext></mpadded>
+    <mpadded voffset="2em">
+        <mtext>foobar</mtext>
+    </mpadded>
 </math>

--- a/crates/mathml-renderer/src/arena.rs
+++ b/crates/mathml-renderer/src/arena.rs
@@ -5,6 +5,7 @@ use stable_arena::DroplessArena;
 
 use crate::{
     ast::{AHref, MultiscriptPair, Node},
+    length::LengthSet,
     super_char::SuperChar,
     table::{ArraySpec, ColumnSpec, RowLabelInfo},
 };
@@ -81,6 +82,10 @@ impl Arena {
     ) -> &'arena &'arena [MultiscriptPair<'pairs>] {
         let fat = self.inner.alloc_slice(pairs);
         self.inner.alloc(&*fat)
+    }
+
+    pub fn alloc_length_set<'arena>(&'arena self, length_set: LengthSet) -> &'arena LengthSet {
+        self.inner.alloc(length_set)
     }
 }
 

--- a/crates/mathml-renderer/src/arena.rs
+++ b/crates/mathml-renderer/src/arena.rs
@@ -84,7 +84,7 @@ impl Arena {
         self.inner.alloc(&*fat)
     }
 
-    pub fn alloc_length_set<'arena>(&'arena self, length_set: LengthSet) -> &'arena LengthSet {
+    pub fn alloc_length_set(&self, length_set: LengthSet) -> &LengthSet {
         self.inner.alloc(length_set)
     }
 }

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -145,7 +145,7 @@ pub enum Node<'arena> {
     Text {
         text_style: Option<HtmlTextStyle>,
         text_size: Option<HtmlTextSize>,
-        text_voffset: Option<LengthSet>,
+        text_voffset: Option<&'arena LengthSet>,
         text: &'arena str,
     },
     /// `<mtext><a href="...">...</a></mtext>`.

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -137,6 +137,7 @@ pub enum Node<'arena> {
         height_0: bool,
         left: Option<MathSpacing>,
         right: Option<MathSpacing>,
+        voffset: Option<&'arena LengthSet>,
     },
     /// `<mphantom>...</mphantom>`
     Phantom { node: &'arena Node<'arena> },
@@ -145,7 +146,6 @@ pub enum Node<'arena> {
     Text {
         text_style: Option<HtmlTextStyle>,
         text_size: Option<HtmlTextSize>,
-        text_voffset: Option<&'arena LengthSet>,
         text: &'arena str,
     },
     /// `<mtext><a href="...">...</a></mtext>`.
@@ -371,16 +371,8 @@ impl<'state> Emitter<'state> {
             Node::Text {
                 text_style,
                 text_size,
-                text_voffset,
                 text: letters,
             } => {
-                if let Some(voffset) = text_voffset {
-                    for voffset in voffset.iter() {
-                        write!(self.s, "<mpadded voffset=\"")?;
-                        voffset.push_to_string(&mut self.s);
-                        write!(self.s, "\">")?;
-                    }
-                }
                 write!(self.s, "<mtext")?;
                 if let Some(size) = text_size {
                     write!(self.s, " style=\"font-size:{}\"", <&str>::from(size))?;
@@ -405,11 +397,6 @@ impl<'state> Emitter<'state> {
                     Some(HtmlTextStyle::Underline) => ("<u>", "</u>"),
                 };
                 write!(self.s, ">{open}{}{close}</mtext>", EscapeHtml(letters))?;
-                if let Some(voffset) = text_voffset {
-                    for _ in voffset.iter() {
-                        write!(self.s, "</mpadded>")?;
-                    }
-                }
             }
             Node::Space(space) => {
                 write!(self.s, "<mspace ")?;
@@ -591,8 +578,26 @@ impl<'state> Emitter<'state> {
                 height_0,
                 left,
                 right,
+                voffset,
             } => {
                 write!(self.s, "<mpadded")?;
+                if let Some(voffset) = voffset {
+                    let mut voffset_iter = voffset.iter();
+                    // I really, really wish `calc()` worked. But I tried it, and it didn't.
+                    // To produce reasonably minimal XML, the last voffset component is
+                    // attached to the "primary" `<mpadded>` element. Any others get put on
+                    // wrapper elements.
+                    if let Some(voffset_length) = voffset_iter.next() {
+                        write!(self.s, r#" voffset=""#)?;
+                        voffset_length.push_to_string(&mut self.s);
+                        write!(self.s, r#"""#)?;
+                    }
+                    for voffset_length in voffset_iter {
+                        write!(self.s, r#"><mpadded voffset=""#)?;
+                        voffset_length.push_to_string(&mut self.s);
+                        write!(self.s, r#"""#)?;
+                    }
+                }
                 if width_0 {
                     write!(self.s, r#" width="0""#)?;
                 }
@@ -612,6 +617,11 @@ impl<'state> Emitter<'state> {
                 write!(self.s, ">")?;
                 self.emit(node, child_indent)?;
                 writeln_indent!(self, base_indent, "</mpadded>");
+                if let Some(voffset) = voffset {
+                    for _ in voffset.iter().skip(1) {
+                        write!(self.s, r#"</mpadded>"#)?;
+                    }
+                }
             }
             Node::Phantom { node } => {
                 write!(self.s, "<mphantom>")?;
@@ -1443,8 +1453,37 @@ mod tests {
                 height_0: false,
                 left: None,
                 right: Some(MathSpacing::FourMu),
+                voffset: None,
             }),
             "<mpadded width=\"0\" style=\"padding-right:0.2222em;\"><mn>x</mn></mpadded>"
+        );
+        assert_eq!(
+            render(&Node::Padded {
+                node: &Node::Number("x"),
+                width_0: true,
+                height_0: false,
+                left: None,
+                right: Some(MathSpacing::FourMu),
+                voffset: Length::from_parts(LengthValue(1.0), LengthUnit::Em)
+                    .map(LengthSet::from)
+                    .as_ref(),
+            }),
+            "<mpadded voffset=\"1em\" width=\"0\" style=\"padding-right:0.2222em;\"><mn>x</mn></mpadded>"
+        );
+        let a = Length::from_parts(LengthValue(1.0), LengthUnit::Em).unwrap();
+        let b = Length::from_parts(LengthValue(2.0), LengthUnit::Rem).unwrap();
+        let c = Length::from_parts(LengthValue(3.0), LengthUnit::Ex).unwrap();
+        let voffset = LengthSet::from(a) + LengthSet::from(b) + LengthSet::from(c);
+        assert_eq!(
+            render(&Node::Padded {
+                node: &Node::Number("x"),
+                width_0: true,
+                height_0: false,
+                left: None,
+                right: Some(MathSpacing::FourMu),
+                voffset: Some(&voffset),
+            }),
+            "<mpadded voffset=\"2rem\"><mpadded voffset=\"1em\"><mpadded voffset=\"3ex\" width=\"0\" style=\"padding-right:0.2222em;\"><mn>x</mn></mpadded></mpadded></mpadded>"
         );
     }
 
@@ -1488,7 +1527,6 @@ mod tests {
             render(&Node::Text {
                 text_style: None,
                 text_size: None,
-                text_voffset: None,
                 text: "hello"
             }),
             "<mtext>hello</mtext>"

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -15,7 +15,7 @@ use crate::attribute::RowAttrs;
 use crate::escaping::{EscapeHtml, FRAGMENT_SAFE};
 use crate::fmt::new_line_and_indent;
 use crate::itoa::append_u8_as_hex;
-use crate::length::{Length, LengthUnit, LengthValue};
+use crate::length::{Length, LengthSet, LengthUnit, LengthValue};
 use crate::symbol::MathMLOperator;
 use crate::table::{
     Alignment, ArraySpec, BORDER_TOP_DASHED, BORDER_TOP_SOLID, ColumnGenerator, LineType,
@@ -142,7 +142,12 @@ pub enum Node<'arena> {
     Phantom { node: &'arena Node<'arena> },
     /// `<mtext>...</mtext>`.
     /// The `str` gets HTML-escaped.
-    Text(Option<HtmlTextStyle>, Option<HtmlTextSize>, &'arena str),
+    Text {
+        text_style: Option<HtmlTextStyle>,
+        text_size: Option<HtmlTextSize>,
+        text_voffset: Option<LengthSet>,
+        text: &'arena str,
+    },
     /// `<mtext><a href="...">...</a></mtext>`.
     /// The link and text get HTML-escaped.
     AHref(&'arena AHref<'arena>),
@@ -363,7 +368,19 @@ impl<'state> Emitter<'state> {
                     EscapeHtml(letters)
                 )?;
             }
-            Node::Text(text_style, text_size, letters) => {
+            Node::Text {
+                text_style,
+                text_size,
+                text_voffset,
+                text: letters,
+            } => {
+                if let Some(voffset) = text_voffset {
+                    for voffset in voffset.iter() {
+                        write!(self.s, "<mpadded voffset=\"")?;
+                        voffset.push_to_string(&mut self.s);
+                        write!(self.s, "\">")?;
+                    }
+                }
                 write!(self.s, "<mtext")?;
                 if let Some(size) = text_size {
                     write!(self.s, " style=\"font-size:{}\"", <&str>::from(size))?;
@@ -388,6 +405,11 @@ impl<'state> Emitter<'state> {
                     Some(HtmlTextStyle::Underline) => ("<u>", "</u>"),
                 };
                 write!(self.s, ">{open}{}{close}</mtext>", EscapeHtml(letters))?;
+                if let Some(voffset) = text_voffset {
+                    for _ in voffset.iter() {
+                        write!(self.s, "</mpadded>")?;
+                    }
+                }
             }
             Node::Space(space) => {
                 write!(self.s, "<mspace ")?;
@@ -1463,7 +1485,12 @@ mod tests {
     #[test]
     fn render_text() {
         assert_eq!(
-            render(&Node::Text(None, None, "hello")),
+            render(&Node::Text {
+                text_style: None,
+                text_size: None,
+                text_voffset: None,
+                text: "hello"
+            }),
             "<mtext>hello</mtext>"
         );
     }

--- a/crates/mathml-renderer/src/length.rs
+++ b/crates/mathml-renderer/src/length.rs
@@ -81,6 +81,86 @@ impl Length {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct LengthSet {
+    pub rem: LengthValue,
+    pub em: LengthValue,
+    pub ex: LengthValue,
+}
+
+impl LengthSet {
+    pub fn zero() -> LengthSet {
+        LengthSet {
+            rem: LengthValue(0.0),
+            em: LengthValue(0.0),
+            ex: LengthValue(0.0),
+        }
+    }
+    pub fn iter(self) -> impl Iterator<Item = Length> {
+        struct Iter(LengthSet);
+        impl Iterator for Iter {
+            type Item = Length;
+            fn next(&mut self) -> Option<Length> {
+                if self.0.rem.0 != 0.0 {
+                    let rem = Length::from_parts(self.0.rem, LengthUnit::Rem);
+                    self.0.rem.0 = 0.0;
+                    rem
+                } else if self.0.em.0 != 0.0 {
+                    let em = Length::from_parts(self.0.em, LengthUnit::Em);
+                    self.0.em.0 = 0.0;
+                    em
+                } else if self.0.ex.0 != 0.0 {
+                    let ex = Length::from_parts(self.0.ex, LengthUnit::Ex);
+                    self.0.ex.0 = 0.0;
+                    ex
+                } else {
+                    None
+                }
+            }
+        }
+        Iter(self)
+    }
+}
+
+impl From<Length> for LengthSet {
+    fn from(value: Length) -> Self {
+        LengthSet::zero() + value
+    }
+}
+
+impl core::ops::AddAssign for LengthSet {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = LengthSet {
+            rem: LengthValue(self.rem.0 + rhs.rem.0),
+            em: LengthValue(self.em.0 + rhs.em.0),
+            ex: LengthValue(self.ex.0 + rhs.ex.0),
+        };
+    }
+}
+
+impl core::ops::Add<LengthSet> for LengthSet {
+    type Output = LengthSet;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl core::ops::Add<Length> for LengthSet {
+    type Output = LengthSet;
+
+    fn add(mut self, rhs: Length) -> Self::Output {
+        match rhs.into_parts() {
+            (value, LengthUnit::Rem) => self.rem.0 += value.0,
+            (value, LengthUnit::Em) => self.em.0 += value.0,
+            (value, LengthUnit::Ex) => self.ex.0 += value.0,
+        }
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This commit implements the basic `\raisebox{length}{text}` syntax, including the ability to nest boxes. It doesn't implement any of the optional parameters, or more obscure box management TeX features like plain `\raise`.