### PR TITLE
Add a way to prefix all IDs with a string

### DIFF
--- a/crates/math-core-python/src/lib.rs
+++ b/crates/math-core-python/src/lib.rs
@@ -40,7 +40,8 @@ impl LatexToMathML {
         global_group=false,
         fancy_error=true,
         unicode_substitution="conventional",
-        max_expansions=MaxExpansions::default().0))]
+        max_expansions=MaxExpansions::default().0,
+        id_prefix=""))]
     fn new(
         pretty_print: &str,
         macros: Option<&Bound<'_, PyDict>>,
@@ -53,6 +54,7 @@ impl LatexToMathML {
         fancy_error: bool,
         unicode_substitution: &str,
         max_expansions: u32,
+        id_prefix: &str,
     ) -> PyResult<Self> {
         let pretty_print = match pretty_print {
             "never" => PrettyPrint::Never,
@@ -91,6 +93,7 @@ impl LatexToMathML {
             css_classes: CssClassNames::default(),
             indentation: math_core::Indentation::default(),
             max_expansions: MaxExpansions(max_expansions),
+            id_prefix: String::from(id_prefix),
         };
 
         let inner = math_core::LatexToMathML::new(config);

--- a/crates/math-core-wasm/src/lib.rs
+++ b/crates/math-core-wasm/src/lib.rs
@@ -150,6 +150,9 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     fn maxExpansions(this: &MathCoreOptions) -> Option<u32>;
+
+    #[wasm_bindgen(method, getter)]
+    fn idPrefix(this: &MathCoreOptions) -> Option<String>;
 }
 
 #[wasm_bindgen]
@@ -225,6 +228,7 @@ impl LatexToMathML {
         } else {
             math_core::UnicodeSubstitution::default()
         };
+        let id_prefix = js_config.idPrefix();
         let config = math_core::MathCoreConfig {
             pretty_print: pretty_print.unwrap_or_default(),
             macros: macros.unwrap_or_default(),
@@ -239,6 +243,7 @@ impl LatexToMathML {
             max_expansions: js_config
                 .maxExpansions()
                 .map_or_else(MaxExpansions::default, MaxExpansions),
+            id_prefix: id_prefix.unwrap_or_default(),
         };
         let convert = math_core::LatexToMathML::new(config).map_err(|(e, _, context)| {
             let start = byte_offset_to_utf16_offset(&context, e.0.start) as u32;

--- a/crates/math-core-wasm/src/lib.rs
+++ b/crates/math-core-wasm/src/lib.rs
@@ -99,6 +99,7 @@ interface MathCoreOptions {
     globalGroup?: boolean;
     unicodeSubstitution?: "never" | "conventional";
     maxExpansions?: number;
+    idPrefix?: string;
 }
 
 interface MathSnippet {

--- a/crates/math-core/src/lib.rs
+++ b/crates/math-core/src/lib.rs
@@ -226,6 +226,9 @@ pub struct MathCoreConfig {
     /// How many custom commands may be expanded in one snippet before the conversion gives up.
     /// See [`MaxExpansions`].
     pub max_expansions: MaxExpansions,
+    /// Add this string to the start of every generated `id` attribute.
+    /// This is *not* URL escaped. Use the [`percent_encoding`] crate if you need to.
+    pub id_prefix: String,
 }
 
 /// Subset of `MathCoreConfig` relevant for the parser.
@@ -247,6 +250,7 @@ struct EmitterConfig {
     annotation: bool,
     css_classes: CssClassNames,
     indentation: Indentation,
+    id_prefix: String,
 }
 
 impl From<MathCoreConfig> for EmitterConfig {
@@ -258,6 +262,7 @@ impl From<MathCoreConfig> for EmitterConfig {
             annotation: config.annotation,
             css_classes: config.css_classes,
             indentation: config.indentation,
+            id_prefix: config.id_prefix,
         }
     }
 }
@@ -450,6 +455,7 @@ fn emit(
             label_map,
             &flags.css_classes,
             flags.indentation,
+            &flags.id_prefix,
         );
         let _ = emitter.emit(node, children_indent);
         warnings = emitter.warnings();
@@ -466,6 +472,7 @@ fn emit(
             label_map,
             &flags.css_classes,
             flags.indentation,
+            &flags.id_prefix,
         );
         for node in ast {
             // We ignore the result of `emit` here, because the only possible error is a formatting

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -276,6 +276,7 @@ pub struct Emitter<'state> {
     css_classes: &'state CssClassNames,
     indentation: Indentation,
     warnings: Warnings,
+    id_prefix: &'state str,
 }
 
 impl<'state> Emitter<'state> {
@@ -284,6 +285,7 @@ impl<'state> Emitter<'state> {
         label_map: &'state FxHashMap<Box<str>, Box<str>>,
         css_classes: &'state CssClassNames,
         indentation: Indentation,
+        id_prefix: &'state str,
     ) -> Self {
         Self {
             s,
@@ -291,6 +293,7 @@ impl<'state> Emitter<'state> {
             css_classes,
             indentation,
             warnings: Warnings::new(),
+            id_prefix,
         }
     }
 
@@ -799,9 +802,10 @@ impl<'state> Emitter<'state> {
                 };
                 write!(
                     self.s,
-                    r##"<mtext><a href="#{}">({})</a></mtext>"##,
-                    percent_encode(label.as_bytes(), FRAGMENT_SAFE),
-                    EscapeHtml(tag)
+                    r##"<mtext><a href="#{id_prefix}{id}">({text})</a></mtext>"##,
+                    id_prefix = self.id_prefix,
+                    id = percent_encode(label.as_bytes(), FRAGMENT_SAFE),
+                    text = EscapeHtml(tag),
                 )?;
             }
             Node::UnknownCommand(cmd_name) => {
@@ -859,6 +863,7 @@ impl<'state> Emitter<'state> {
                             label_info,
                             numbering_cols,
                             self.indentation,
+                            self.id_prefix,
                         )?;
                     }
                     writeln_indent!(self, child_indent, "</mtr>");
@@ -891,6 +896,7 @@ impl<'state> Emitter<'state> {
                 last_row_info,
                 numbering_cols,
                 self.indentation,
+                self.id_prefix,
             )?;
         }
         writeln_indent!(self, child_indent, "</mtr>");
@@ -984,6 +990,7 @@ fn write_equation_num(
     label_info: Option<&RowLabelInfo>,
     numbering_cols: NumberColums,
     indentation: Indentation,
+    id_prefix: &str,
 ) -> Result<(), core::fmt::Error> {
     numbering_cols.dummy_column_opening(s, child_indent2, indentation)?;
     if let Some(label_info) = label_info {
@@ -991,8 +998,8 @@ fn write_equation_num(
         if let Some(link_target) = label_info.link_target {
             write!(
                 s,
-                r#" id="{}">"#,
-                percent_encode(link_target.as_bytes(), FRAGMENT_SAFE)
+                r#" id="{id_prefix}{id}">"#,
+                id = percent_encode(link_target.as_bytes(), FRAGMENT_SAFE)
             )?;
         } else {
             write!(s, ">")?;
@@ -1069,7 +1076,13 @@ mod tests {
         let output = String::new();
         let label_map = FxHashMap::default();
         let css_classes = CssClassNames::default();
-        let mut emitter = Emitter::new(output, &label_map, &css_classes, Indentation::default());
+        let mut emitter = Emitter::new(
+            output,
+            &label_map,
+            &css_classes,
+            Indentation::default(),
+            "test-id-prefix-",
+        );
         emitter.emit(node, 0).unwrap();
         emitter.into_string()
     }
@@ -1498,6 +1511,14 @@ mod tests {
     }
 
     #[test]
+    fn render_eqref() {
+        assert_eq!(
+            render(&Node::EqRef("thing")),
+            "<mtext><a href=\"#test-id-prefix-thing\">(??)</a></mtext>"
+        );
+    }
+
+    #[test]
     fn render_sized_operator() {
         assert_eq!(
             render(&Node::Operator {
@@ -1603,6 +1624,53 @@ mod tests {
                 last_row_info: None,
             }),
             "<mtable displaystyle=\"true\" scriptlevel=\"0\" style=\"width: 100%\"><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd style=\"width: 50%;text-align: right;justify-items: end;\"><mtext>(1)</mtext></mtd></mtr><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd><mtd style=\"width: 50%\"></mtd></mtr></mtable>"
+        );
+    }
+
+    #[test]
+    fn render_equation_array_with_link_target() {
+        let nodes = [
+            &Node::Number("1"),
+            &Node::ColumnSeparator,
+            &Node::Number("2"),
+            &Node::RowSeparator {
+                label_info: Some(&RowLabelInfo {
+                    tag: EquationTag {
+                        text: "1",
+                        parenthesized: true,
+                    },
+                    link_target: Some("eq:1"),
+                }),
+                border_top: None,
+            },
+            &Node::Number("3"),
+            &Node::ColumnSeparator,
+            &Node::Number("4"),
+        ];
+
+        let info_with_tag = RowLabelInfo {
+            tag: EquationTag {
+                text: "2",
+                parenthesized: true,
+            },
+            link_target: Some("eq:2"),
+        };
+        assert_eq!(
+            render(&Node::EquationArray {
+                content: &nodes,
+                align: Alignment::Centered,
+                last_row_info: Some(&info_with_tag),
+            }),
+            "<mtable displaystyle=\"true\" scriptlevel=\"0\" style=\"width: 100%\"><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd style=\"width: 50%;text-align: right;justify-items: end;\" id=\"test-id-prefix-eq:1\"><mtext>(1)</mtext></mtd></mtr><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd><mtd style=\"width: 50%;text-align: right;justify-items: end;\" id=\"test-id-prefix-eq:2\"><mtext>(2)</mtext></mtd></mtr></mtable>"
+        );
+
+        assert_eq!(
+            render(&Node::EquationArray {
+                content: &nodes,
+                align: Alignment::Centered,
+                last_row_info: None,
+            }),
+            "<mtable displaystyle=\"true\" scriptlevel=\"0\" style=\"width: 100%\"><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd style=\"width: 50%;text-align: right;justify-items: end;\" id=\"test-id-prefix-eq:1\"><mtext>(1)</mtext></mtd></mtr><mtr><mtd style=\"width: 50%\"></mtd><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd><mtd style=\"width: 50%\"></mtd></mtr></mtable>"
         );
     }
 

--- a/crates/mathml-renderer/src/lib.rs
+++ b/crates/mathml-renderer/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! let label_map = FxHashMap::default();
 //! let css_classes = CssClassNames::default();
-//! let mut emitter = Emitter::new(String::new(), &label_map, &css_classes, Indentation::default());
+//! let mut emitter = Emitter::new(String::new(), &label_map, &css_classes, Indentation::default(), "");
 //! emitter.emit(&ast, 0).unwrap();
 //! let output = emitter.into_string();
 //! assert_eq!(

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -193,6 +193,7 @@ new LatexToMathML(options: MathCoreOptions)
 | `annotation` | `boolean` | `false` | Include the original LaTeX as an annotation in the MathML output. |
 | `globalGroup` | `boolean` | `false` | Run the conversion in the global group, so that commands defined with `\newcommand` stay defined for subsequent calls to `convert_with_global_state`. If `false`, such definitions are local to the snippet which contains them. |
 | `maxExpansions` | `number` | `1000` | How many custom commands may be expanded in one snippet before the conversion gives up. The limit exists because a macro may expand to itself, directly or indirectly. |
+| `idPrefix`      | `string` | `""`   | Added to the beginning of every `id` and anchor reference. Use this to avoid conflicts when embedding the output. |
 
 **Methods:**
 

--- a/python/math_core/_math_core_rust.pyi
+++ b/python/math_core/_math_core_rust.pyi
@@ -16,6 +16,7 @@ class LatexToMathML:
         fancy_error: bool = True,
         unicode_substitution: Literal["never", "conventional"] = "conventional",
         max_expansions: int = 1000,
+        id_prefix: string = "",
     ) -> None:
         r"""Create a LatexToMathML converter with the specified configuration.
 
@@ -60,6 +61,9 @@ class LatexToMathML:
             max_expansions: The number of custom command expansions allowed in one
                 snippet. This limit exists because a macro may expand to itself,
                 directly or indirectly, in which case the expansion would never end.
+
+            id_prefix: Added to the beginning of every ``id`` and anchor reference.
+                Use this to avoid conflicts when embedding the output.
         """
     def convert_with_global_state(self, latex: str, *, displaystyle: bool) -> str:
         """Convert LaTeX to MathML with a global counter for equation numbering."""


### PR DESCRIPTION
This allows us to have independent, logical documents with their own label and counter namespaces on the same HTML page without conflicts.