### PR TITLE
Use `chars().count()` to validate macro names

### DIFF
--- a/crates/math-core/src/custom_cmds.rs
+++ b/crates/math-core/src/custom_cmds.rs
@@ -249,11 +249,8 @@ pub(crate) fn is_valid_macro_name(s: &str) -> bool {
     if s.is_empty() {
         return false;
     }
-    let mut chars = s.chars();
-    match (chars.next(), chars.next()) {
-        // If the name contains only one character, any character is valid.
-        (Some(_), None) => true,
+    // If the name contains only one character, any character is valid.
+    s.chars().count() == 1
         // If the name contains more than one character, all characters must be ASCII alphabetic.
-        _ => s.bytes().all(|b| b.is_ascii_alphabetic()),
-    }
+        || s.bytes().all(|b| b.is_ascii_alphabetic())
 }


### PR DESCRIPTION
This takes advantage of a [fast path][] in the standard library for counting UTF-8 characters without fully decoding them.

[fast path]: https://doc.rust-lang.org/1.98.0/src/core/str/count.rs.html

Before
------

    % wc -c playground/pkg/math_core_wasm_bg.wasm
      204298 playground/pkg/math_core_wasm_bg.wasm

After
-----

    % wc -c playground/pkg/math_core_wasm_bg.wasm
      204276 playground/pkg/math_core_wasm_bg.wasm