### PR TITLE
Don't allow arbitrary attributes on PseudoOp

### DIFF
--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -1095,20 +1095,19 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let bounds = bounds_limits.bounds;
 
                 let limits_by_default = matches!(tok, Token::PseudoOperatorLimits(_));
-                let (use_underover, attrs) = match (bounds_limits.limits(), limits_by_default) {
-                    _ if bounds.is_trivial() => (false, OpAttrs::empty()),
-                    (None, true) | (Some(LimitsKind::Display), _) => {
-                        (true, OpAttrs::FORCE_MOVABLE_LIMITS)
-                    }
-                    (None, false) | (Some(LimitsKind::Never), _) => (false, OpAttrs::empty()),
-                    (Some(LimitsKind::Always), _) => (true, OpAttrs::empty()),
-                };
+                let (use_underover, force_movable_limits) =
+                    match (bounds_limits.limits(), limits_by_default) {
+                        _ if bounds.is_trivial() => (false, false),
+                        (None, true) | (Some(LimitsKind::Display), _) => (true, true),
+                        (None, false) | (Some(LimitsKind::Never), _) => (false, false),
+                        (Some(LimitsKind::Always), _) => (true, false),
+                    };
 
                 // Compute spacing after getting the bounds, so that we don't
                 // consider tokens that are part of the bounds for spacing calculations.
                 let (left, right) = self.mathop_spacing(parse_as, prev_class, true)?;
                 let target = self.commit(Node::PseudoOp {
-                    attrs,
+                    force_movable_limits,
                     left,
                     right,
                     name,
@@ -1183,7 +1182,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
 
                     Node::PseudoOp {
                         name,
-                        attrs,
+                        force_movable_limits,
                         left,
                         right,
                     } => {
@@ -1195,7 +1194,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                         let name = builder.finish(self.arena);
                         Ok(Node::PseudoOp {
                             name,
-                            attrs,
+                            force_movable_limits,
                             left,
                             right,
                         })
@@ -1568,20 +1567,19 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let bounds_limits = self.get_bounds(None)?;
                 let bounds = bounds_limits.bounds;
 
-                let (use_underover, attrs) = match (bounds_limits.limits(), with_limits) {
-                    _ if bounds.is_trivial() => (false, OpAttrs::empty()),
-                    (None, true) | (Some(LimitsKind::Display), _) => {
-                        (true, OpAttrs::FORCE_MOVABLE_LIMITS)
-                    }
-                    (None, false) | (Some(LimitsKind::Never), _) => (false, OpAttrs::empty()),
-                    (Some(LimitsKind::Always), _) => (true, OpAttrs::empty()),
-                };
+                let (use_underover, force_movable_limits) =
+                    match (bounds_limits.limits(), with_limits) {
+                        _ if bounds.is_trivial() => (false, false),
+                        (None, true) | (Some(LimitsKind::Display), _) => (true, true),
+                        (None, false) | (Some(LimitsKind::Never), _) => (false, false),
+                        (Some(LimitsKind::Always), _) => (true, false),
+                    };
 
                 // Compute spacing after getting the bounds, so that we don't
                 // consider tokens that are part of the bounds for spacing calculations.
                 let (left, right) = self.mathop_spacing(parse_as, prev_class, true)?;
                 let op = self.commit(Node::PseudoOp {
-                    attrs,
+                    force_movable_limits,
                     left,
                     right,
                     name: letters,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathit_func.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathit_func.snap
@@ -7,7 +7,7 @@ expression: "\\mathit{ab \\log cd}"
     nodes: [
       IdentifierStr("𝑎𝑏"),
       PseudoOp(
-        attrs: OpAttrs(""),
+        force_movable_limits: false,
         left: Some(ThreeMu),
         right: Some(ThreeMu),
         name: "log",

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathit_of_max.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathit_of_max.snap
@@ -7,7 +7,7 @@ expression: "\\mathit{ab \\max \\alpha\\beta}"
     nodes: [
       IdentifierStr("𝑎𝑏"),
       PseudoOp(
-        attrs: OpAttrs(""),
+        force_movable_limits: false,
         left: Some(ThreeMu),
         right: Some(ThreeMu),
         name: "max",

--- a/crates/math-core/src/snapshots/math_core__parser__tests__operatorname_number.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__operatorname_number.snap
@@ -4,7 +4,7 @@ expression: "\\operatorname123"
 ---
 [
   PseudoOp(
-    attrs: OpAttrs(""),
+    force_movable_limits: false,
     left: Some(Zero),
     right: Some(ThreeMu),
     name: "1",

--- a/crates/mathml-renderer/src/ast.rs
+++ b/crates/mathml-renderer/src/ast.rs
@@ -67,7 +67,7 @@ pub enum Node<'arena> {
     },
     /// `<mo>...</mo>` for a string.
     PseudoOp {
-        attrs: OpAttrs,
+        force_movable_limits: bool,
         left: Option<MathSpacing>,
         right: Option<MathSpacing>,
         name: &'arena str,
@@ -350,11 +350,16 @@ impl<'state> Emitter<'state> {
                 write!(self.s, ">{op}</mo>")?;
             }
             Node::PseudoOp {
-                attrs,
+                force_movable_limits,
                 left,
                 right,
                 name,
             } => {
+                let attrs = if force_movable_limits {
+                    OpAttrs::FORCE_MOVABLE_LIMITS
+                } else {
+                    OpAttrs::empty()
+                };
                 emit_operator_attributes(&mut self.s, attrs, left, right)?;
                 write!(self.s, ">{name}</mo>")?;
             }
@@ -1166,7 +1171,7 @@ mod tests {
     fn render_pseudo_operator() {
         assert_eq!(
             render(&Node::PseudoOp {
-                attrs: OpAttrs::empty(),
+                force_movable_limits: false,
                 left: Some(MathSpacing::ThreeMu),
                 right: Some(MathSpacing::ThreeMu),
                 name: "sin"
@@ -1286,7 +1291,7 @@ mod tests {
             render(&Node::Under {
                 symbol: &Node::IdentifierChar('θ'.into(), LetterAttr::Default),
                 target: &Node::PseudoOp {
-                    attrs: OpAttrs::FORCE_MOVABLE_LIMITS,
+                    force_movable_limits: true,
                     left: Some(MathSpacing::ThreeMu),
                     right: Some(MathSpacing::ThreeMu),
                     name: "min",


### PR DESCRIPTION
The motivation is to ensure things don't get too complicated when we address #668.