### PR TITLE
Avoid quadratic blow-up in line-column computation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ testpage: $(SUBSET_WOFF2)
 	cargo run --example browser_test --package math-core > playground/test.html
 
 comparison: $(SUBSET_WOFF2) playground/mathmlfixes.css
-	cargo run --bin mathcore -- -c docs/mathcore.toml --inline-del ₮ --block-del ₮₮ --continue-on-error docs/comparison.html > playground/comparison.html
-	cargo run --bin mathcore -- -c docs/unicode_math_symbols.toml --inline-open '\(' --inline-close '\)' docs/unicode-math-table.html > playground/unicode-math-table.html
+	cargo run --bin mathcore -- -c docs/mathcore.toml --inline-del ₮ --block-del ₮₮ --continue-on-error --quiet docs/comparison.html > playground/comparison.html
+	cargo run --bin mathcore -- -c docs/unicode_math_symbols.toml --inline-open '\(' --inline-close '\)' --quiet docs/unicode-math-table.html > playground/unicode-math-table.html
 
 allsymbols: scripts/all_symbols.txt
 

--- a/crates/math-core-cli/src/main.rs
+++ b/crates/math-core-cli/src/main.rs
@@ -100,6 +100,10 @@ struct Args {
     #[arg(long, conflicts_with = "formula")]
     continue_on_error: bool,
 
+    /// Suppress warnings; errors are still reported
+    #[arg(short, long)]
+    quiet: bool,
+
     /// Specifies a single LaTeX formula
     #[arg(short, long, conflicts_with = "file")]
     formula: Option<String>,
@@ -173,7 +177,9 @@ fn main() {
             let input = read_stdin();
             match replace(&replacer, &input, &converter, args.continue_on_error) {
                 Ok(converted) => {
-                    print_warnings(&converted.warnings, None);
+                    if !args.quiet {
+                        print_warnings(&converted.warnings, None);
+                    }
                     println!("{}", converted.html);
                 }
                 Err(e) => exit_conversion_error(e, None),
@@ -310,7 +316,9 @@ fn convert_html(
     let original = fs::read_to_string(fp).unwrap_or_else(|e| exit_io_error(&e));
     let converted = replace(replacer, &original, converter, args.continue_on_error)
         .unwrap_or_else(|e| exit_conversion_error(e, Some(fp)));
-    print_warnings(&converted.warnings, Some(fp));
+    if !args.quiet {
+        print_warnings(&converted.warnings, Some(fp));
+    }
     if args.dry_run {
         return;
     }

--- a/crates/math-core-cli/src/main.rs
+++ b/crates/math-core-cli/src/main.rs
@@ -13,7 +13,7 @@ mod config_file;
 mod html_entities;
 mod replace;
 
-use replace::{ConversionError, Replacer, SnippetWarning};
+use replace::{ConversionError, LineTracker, Replacer, SnippetWarning};
 
 static DEFAULT_CONFIG_FILE: &str = "mathcore.toml";
 
@@ -229,12 +229,15 @@ fn replace<'source>(
     input: &'source str,
     converter: &LatexToMathML,
     continue_on_error: bool,
-) -> Result<Converted<'source>, ConversionError<'source>> {
+) -> Result<Converted, ConversionError<'source>> {
     let scan = replacer.scan(input)?;
     let converted = converter.convert_all(&scan.snippets);
 
     let mut result = String::with_capacity(input.len());
     let mut warnings = Vec::new();
+    // One tracker for the whole document: the sites are visited in document order, so it never
+    // has to look back at a part of the input it has already passed.
+    let mut tracker = LineTracker::new(input);
     for (((latex, display), site), converted) in
         scan.snippets.into_iter().zip(&scan.sites).zip(converted)
     {
@@ -242,7 +245,11 @@ fn replace<'source>(
         match converted {
             Ok(converted) => {
                 result += &converted.mathml;
-                warnings.extend(SnippetWarning::for_site(input, site, converted.warnings));
+                warnings.extend(SnippetWarning::for_site(
+                    &mut tracker,
+                    site,
+                    converted.warnings,
+                ));
             }
             Err(err) if continue_on_error => {
                 result += &err.to_html(&latex, display, None);
@@ -258,10 +265,10 @@ fn replace<'source>(
 }
 
 /// A converted document, together with everything worth telling the user about the conversion.
-struct Converted<'source> {
+struct Converted {
     html: String,
     /// The warnings of all snippets of the document, in document order.
-    warnings: Vec<SnippetWarning<'source>>,
+    warnings: Vec<SnippetWarning>,
 }
 
 /// Convert all LaTeX equations in all HTML files under a given directory.

--- a/crates/math-core-cli/src/replace.rs
+++ b/crates/math-core-cli/src/replace.rs
@@ -33,7 +33,8 @@ impl<'source> ConversionError<'source> {
 
 impl fmt::Display for ConversionError<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let (line, col) = line_and_col(self.0, self.2);
+        let mut tracker = LineTracker::new(self.2);
+        let (line, col) = tracker.line_and_col(self.0);
         match &self.1 {
             ConvErrKind::UnclosedDelimiter => {
                 write!(f, "Unclosed delimiter on line {line}, column {col}.")
@@ -45,7 +46,7 @@ impl fmt::Display for ConversionError<'_> {
                 )
             }
             ConvErrKind::MismatchedDelimiters(close) => {
-                let (close_line, close_col) = line_and_col(*close, self.2);
+                let (close_line, close_col) = tracker.line_and_col(*close);
                 write!(
                     f,
                     "Mismatched delimiters: opening at line {line}, column {col}, closing at line {close_line}, column {close_col}."
@@ -70,7 +71,11 @@ impl std::error::Error for ConversionError<'_> {}
 /// Unlike a [`ConversionError`], a warning does not stop the conversion; it only points out that
 /// the resulting MathML is probably not what the author intended.
 #[derive(Debug)]
-pub struct SnippetWarning<'source>(usize, WarnKind, &'source str);
+pub struct SnippetWarning {
+    line: usize,
+    col: usize,
+    kind: WarnKind,
+}
 
 #[derive(Debug)]
 enum WarnKind {
@@ -78,14 +83,18 @@ enum WarnKind {
     UnknownCommand,
 }
 
-impl<'source> SnippetWarning<'source> {
+impl SnippetWarning {
     /// The warnings that the snippet found at `site` produced, one per kind.
+    ///
+    /// The position of the site is resolved right here rather than when the warning is printed,
+    /// so `tracker` has to be the one that the rest of the document is resolved with; see
+    /// [`LineTracker`] for why it cannot look backwards.
     pub(crate) fn for_site(
-        input: &'source str,
+        tracker: &mut LineTracker,
         site: &Site,
         warnings: Warnings,
     ) -> impl Iterator<Item = Self> {
-        let offset = site.offset;
+        let (line, col) = tracker.line_and_col(site.offset);
         [
             warnings
                 .has_undefined_references()
@@ -96,39 +105,77 @@ impl<'source> SnippetWarning<'source> {
         ]
         .into_iter()
         .flatten()
-        .map(move |kind| SnippetWarning(offset, kind, input))
+        .map(move |kind| SnippetWarning { line, col, kind })
     }
 }
 
-impl fmt::Display for SnippetWarning<'_> {
+impl fmt::Display for SnippetWarning {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let (line, col) = line_and_col(self.0, self.2);
-        let what = match self.1 {
+        let what = match self.kind {
             WarnKind::UndefinedReference => "undefined reference",
             WarnKind::UnknownCommand => "unknown command",
         };
-        write!(f, "{what} in the formula on line {line}, column {col}.")
+        write!(
+            f,
+            "{what} in the formula on line {}, column {}.",
+            self.line, self.col
+        )
     }
 }
 
-/// Determine line and column numbers of `loc` within the input string.
-fn line_and_col(loc: usize, input: &str) -> (usize, usize) {
-    let mut line = 1;
-    let mut col = 1;
+/// Determines line and column numbers within a document that is scanned from front to back.
+///
+/// Locating every position from the start of the document costs the length of the document per
+/// position, which for a document full of warnings adds up to a quadratic blow up. This resumes
+/// where the previous query stopped instead, so that one pass covers the whole document. Positions
+/// therefore have to be queried in non-decreasing order.
+pub(crate) struct LineTracker<'source> {
+    input: &'source str,
+    /// Every character before this offset has been counted into `line` and `col`.
+    counted: usize,
+    line: usize,
+    col: usize,
+}
 
-    for (i, ch) in input.char_indices() {
-        if i >= loc {
-            break;
-        }
-
-        if ch == '\n' {
-            line += 1;
-            col = 1;
-        } else {
-            col += 1;
+impl<'source> LineTracker<'source> {
+    pub(crate) fn new(input: &'source str) -> Self {
+        LineTracker {
+            input,
+            counted: 0,
+            line: 1,
+            col: 1,
         }
     }
-    (line, col)
+
+    /// Determine line and column numbers of `loc` within the input string.
+    ///
+    /// `loc` must not lie before the location of the previous query.
+    pub(crate) fn line_and_col(&mut self, loc: usize) -> (usize, usize) {
+        debug_assert!(
+            loc >= self.counted,
+            "locations have to be queried in document order"
+        );
+        // Where the scan stopped; if no character is left, everything belongs before `loc`.
+        let mut stop = self.input.len();
+        for (i, ch) in self.input[self.counted..].char_indices() {
+            let i = self.counted + i;
+            if i >= loc {
+                stop = i;
+                break;
+            }
+
+            if ch == '\n' {
+                self.line += 1;
+                self.col = 1;
+            } else {
+                self.col += 1;
+            }
+        }
+        // `stop` is a character boundary even when `loc` is not, which is what keeps the slice
+        // above valid on the next call.
+        self.counted = stop;
+        (self.line, self.col)
+    }
 }
 
 pub struct Replacer<'args> {
@@ -394,6 +441,37 @@ mod tests {
         }
         result.push_str(scan.trailing_text);
         Ok(result)
+    }
+
+    /// Resuming from the previous query has to give the same answer as locating every position
+    /// from the start of the document. The input mixes in a multi-byte character so that a column
+    /// counted in bytes would show up as a wrong number.
+    #[test]
+    fn line_tracker_resumes_where_it_stopped() {
+        let input = "a\u{00e4}b\nsecond line\n\nfourth $x$ line\n";
+        let mut tracker = LineTracker::new(input);
+        for loc in 0..=input.len() {
+            if !input.is_char_boundary(loc) {
+                continue;
+            }
+            let from_scratch = LineTracker::new(input).line_and_col(loc);
+            assert_eq!(
+                tracker.line_and_col(loc),
+                from_scratch,
+                "resuming disagreed at offset {loc}"
+            );
+        }
+    }
+
+    /// The same offset asked for twice must not move the cursor past it.
+    #[test]
+    fn line_tracker_repeats_a_query() {
+        let input = "first\nsecond\n";
+        let mut tracker = LineTracker::new(input);
+        let start_of_second_line = 6;
+        assert_eq!(tracker.line_and_col(start_of_second_line), (2, 1));
+        assert_eq!(tracker.line_and_col(start_of_second_line), (2, 1));
+        assert_eq!(tracker.line_and_col(input.len()), (3, 1));
     }
 
     #[test]

--- a/crates/math-core-cli/tests/cli.rs
+++ b/crates/math-core-cli/tests/cli.rs
@@ -446,6 +446,38 @@ fn warnings_of_stdin_are_printed_without_a_file_name() {
     );
 }
 
+/// `--quiet` takes the warnings off stderr without touching the converted document.
+#[test]
+fn quiet_suppresses_warnings() {
+    let dir = empty_dir();
+    let mut cmd = mathcore(dir.path());
+    cmd.args(["--quiet", "-"]);
+    let out = run_with_stdin(cmd, UNDEFINED_REF_DOC);
+
+    assert!(out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("<math"));
+    assert_eq!(
+        String::from_utf8_lossy(&out.stderr),
+        "",
+        "--quiet should suppress the warnings"
+    );
+}
+
+/// `--quiet` is about warnings only: an actual conversion error still gets reported, and still
+/// fails the run.
+#[test]
+fn quiet_does_not_suppress_errors() {
+    let dir = empty_dir();
+    write(dir.path(), "doc.html", "before $x$ and $\\frac$ after\n");
+    let out = mathcore(dir.path())
+        .args(["--quiet", "doc.html"])
+        .output()
+        .expect("failed to run mathcore");
+
+    assert_eq!(out.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("Conversion error in 'doc.html'"));
+}
+
 #[test]
 fn a_failing_file_is_left_untouched() {
     let dir = empty_dir();


### PR DESCRIPTION
Also, add a `--quiet` flag.