### PR TITLE
Semantic parsing for mathml equations

### DIFF
--- a/crates/math-core/src/lib.rs
+++ b/crates/math-core/src/lib.rs
@@ -50,6 +50,7 @@ mod html_utils;
 mod lexer;
 mod parser;
 mod predefined;
+mod semantic;
 mod specifications;
 mod split_on_ascii;
 mod string_pool;
@@ -451,7 +452,7 @@ fn emit(
         let children_indent = if pretty_print { 2 } else { 0 };
         new_line_and_indent(&mut output, base_indent, flags.indentation);
         output.push_str("<semantics>");
-        let node = parser::node_vec_to_node(arena, &ast, false);
+        let node = parser::node_vec_to_node(arena, &ast);
         let mut emitter = Emitter::new(
             core::mem::take(&mut output),
             label_map,
@@ -515,7 +516,7 @@ fn parse<'arena>(
     let lexer = Lexer::new(latex);
     let mut p = Parser::new(lexer, arena, parser_cfg, state, style)?;
     let nodes = p.parse()?;
-    Ok(nodes)
+    Ok(semantic::enrich(arena, &nodes))
 }
 
 /// Read the macros of the configuration into a store of custom commands.

--- a/crates/math-core/src/parser.rs
+++ b/crates/math-core/src/parser.rs
@@ -30,7 +30,7 @@ use crate::{
     error::{DelimiterModifier, LatexErrKind, LatexError, LimitedUsabilityToken, Place},
     global_state::GlobalState,
     lexer::{Lexer, recover_limited_ascii},
-    predefined,
+    predefined, semantic,
     specifications::{LatexUnit, parse_column_specification, parse_length_specification},
     split_on_ascii::split_on_ascii,
     text_parser::TextSnippet,
@@ -268,8 +268,8 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 Length::zero().into_parts()
             };
             let frac = self.commit(Node::Frac {
-                num: node_vec_to_node(self.arena, &numerator, false),
-                denom: node_vec_to_node(self.arena, &denominator, false),
+                num: semantic::enrich_to_node(self.arena, &numerator, false),
+                denom: semantic::enrich_to_node(self.arena, &denominator, false),
                 lt_value,
                 lt_unit,
                 attr: None,
@@ -555,7 +555,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let (left, right) = self.state.punctuation_spacing(next_class, true);
                 Ok(Node::Operator {
                     op,
-                    attrs: OpAttrs::empty(),
+                    attrs: OpAttrs::ROLE_PREFIX | OpAttrs::ROLE_INFIX | OpAttrs::ROLE_POSTFIX,
                     left,
                     right,
                     size: None,
@@ -686,7 +686,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 };
                 Ok(Node::Operator {
                     op: binary_op.as_op(),
-                    attrs: OpAttrs::empty(),
+                    attrs: OpAttrs::ROLE_INFIX,
                     left: spacing,
                     right: spacing,
                     size: None,
@@ -705,7 +705,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 };
                 Ok(Node::Operator {
                     op,
-                    attrs: OpAttrs::empty(),
+                    attrs: OpAttrs::ROLE_INFIX,
                     left: spacing,
                     right: spacing,
                     size: None,
@@ -801,7 +801,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let (left, right) = self.state.mathinner_spacing(prev_class, next_class, false);
                 Ok(Node::Operator {
                     op: op.as_op(),
-                    attrs: OpAttrs::empty(),
+                    attrs: OpAttrs::ROLE_INFIX | OpAttrs::ROLE_PREFIX | OpAttrs::ROLE_POSTFIX,
                     left,
                     right,
                     size: None,
@@ -874,7 +874,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     )?;
                     let content = self.parse_next(ParseAs::Arg)?;
                     Ok(Node::Root(
-                        node_vec_to_node(self.arena, &degree, true),
+                        semantic::enrich_to_node(self.arena, &degree, true),
                         content,
                     ))
                 } else {
@@ -1071,7 +1071,11 @@ impl<'state, 'arena> Parser<'state, 'arena> {
 
                 let target = self.commit(Node::Operator {
                     op: op.as_op(),
-                    attrs,
+                    attrs: attrs
+                        | match op.category() {
+                            OpCategory::C => OpAttrs::ROLE_INFIX,
+                            OpCategory::H | OpCategory::J => OpAttrs::ROLE_PREFIX,
+                        },
                     left,
                     right,
                     size: None,
@@ -1242,7 +1246,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 };
                 Ok(Node::Operator {
                     op,
-                    attrs: OpAttrs::empty(),
+                    attrs: OpAttrs::ROLE_INFIX,
                     left,
                     right,
                     size: None,
@@ -1252,7 +1256,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 class = Class::Open;
                 Ok(Node::Operator {
                     op,
-                    attrs: OpAttrs::FORM_PREFIX,
+                    attrs: OpAttrs::FORM_PREFIX | OpAttrs::ROLE_OPEN,
                     left: Some(MathSpacing::Zero),
                     right: Some(MathSpacing::Zero),
                     size: None,
@@ -1262,7 +1266,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 class = Class::Close;
                 Ok(Node::Operator {
                     op,
-                    attrs: OpAttrs::FORM_POSTFIX,
+                    attrs: OpAttrs::FORM_POSTFIX | OpAttrs::ROLE_CLOSE,
                     left: Some(MathSpacing::Zero),
                     right: Some(MathSpacing::Zero),
                     size: None,
@@ -1280,7 +1284,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 )?;
                 return Ok(Parsed::Node(
                     Class::Default,
-                    node_vec_to_node(self.arena, &content, matches!(parse_as, ParseAs::Arg)),
+                    semantic::enrich_to_node(self.arena, &content, matches!(parse_as, ParseAs::Arg)),
                 ));
             }
             ref tok @ (Token::Open(paren) | Token::Close(paren)) => {
@@ -1314,6 +1318,11 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     // so we have to explicitly disable that here.
                     attrs |= OpAttrs::STRETCHY_FALSE;
                 }
+                if open {
+                    attrs |= OpAttrs::ROLE_OPEN;
+                } else {
+                    attrs |= OpAttrs::ROLE_CLOSE;
+                }
                 Ok(Node::Operator {
                     op: paren.as_op(),
                     attrs,
@@ -1326,7 +1335,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 class = Class::Open;
                 Ok(Node::Operator {
                     op: symbol::LEFT_SQUARE_BRACKET.as_op(),
-                    attrs: OpAttrs::STRETCHY_FALSE,
+                    attrs: OpAttrs::STRETCHY_FALSE | OpAttrs::ROLE_OPEN,
                     left: None,
                     right: None,
                     size: None,
@@ -1334,7 +1343,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
             }
             Token::SquareBracketClose => Ok(Node::Operator {
                 op: symbol::RIGHT_SQUARE_BRACKET.as_op(),
-                attrs: OpAttrs::STRETCHY_FALSE,
+                attrs: OpAttrs::STRETCHY_FALSE | OpAttrs::ROLE_CLOSE,
                 left: None,
                 right: None,
                 size: None,
@@ -1393,6 +1402,12 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     }
                     Stretchy::AlwaysAsymmetric => OpAttrs::SYMMETRIC_TRUE,
                     Stretchy::Always => OpAttrs::empty(),
+                };
+                // Semantic role from paren type
+                attrs |= match paren_type {
+                    Some(ParenType::Left) => OpAttrs::ROLE_OPEN,
+                    Some(ParenType::Right) => OpAttrs::ROLE_CLOSE,
+                    Some(ParenType::Middle) | None => OpAttrs::ROLE_INFIX,
                 };
                 // Determine form and spacing attributes based on paren_type
                 // and delimiter spacing.
@@ -1629,7 +1644,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     .collect::<Vec<_>>();
                 return Ok(Parsed::Node(
                     Class::Close,
-                    node_vec_to_node(self.arena, &nodes, false),
+                    node_vec_to_node(self.arena, &nodes),
                 ));
             }
             Token::RaiseBox => {
@@ -1683,7 +1698,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                     .collect::<Vec<_>>();
                 return Ok(Parsed::Node(
                     Class::Close,
-                    node_vec_to_node(self.arena, &nodes, false),
+                    semantic::enrich_to_node(self.arena, &nodes, false),
                 ));
             }
             Token::NewColumn => {
@@ -2208,7 +2223,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                         Class::Open,
                         false,
                     )?;
-                    let under = node_vec_to_node(self.arena, &nodes, false);
+                    let under = semantic::enrich_to_node(self.arena, &nodes, false);
                     let over = self.parse_next(ParseAs::Arg)?;
                     (Some(under), over)
                 } else {
@@ -2225,7 +2240,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let label_space = &const { Node::Space(LatexUnit::Em.length_with_unit(3.5)) };
                 let over_label = self.commit(Node::Over {
                     symbol: label_space,
-                    target: node_vec_to_node(self.arena, &[pad, over_arg, pad], false),
+                    target: semantic::enrich_to_node(self.arena, &[pad, over_arg, pad], false),
                 });
 
                 // Stretchy relation: an arrow from the `A` relation category is stretchy
@@ -2249,7 +2264,7 @@ impl<'state, 'arena> Parser<'state, 'arena> {
                 let center = if let Some(under_arg) = under_arg {
                     let under_label = self.commit(Node::Under {
                         symbol: label_space,
-                        target: node_vec_to_node(self.arena, &[pad, under_arg, pad], false),
+                        target: semantic::enrich_to_node(self.arena, &[pad, under_arg, pad], false),
                     });
                     self.commit(Node::UnderOver {
                         target: arrow,
@@ -3328,24 +3343,9 @@ impl ParserState<'_> {
 pub(crate) fn node_vec_to_node<'arena>(
     arena: &'arena Arena,
     nodes: &[&'arena Node<'arena>],
-    reset_spacing: bool,
 ) -> &'arena Node<'arena> {
     if let [single] = nodes {
-        if reset_spacing {
-            if let Node::Operator { op, attrs, .. } = **single {
-                arena.push(Node::Operator {
-                    op,
-                    attrs,
-                    left: None,
-                    right: None,
-                    size: None,
-                })
-            } else {
-                single
-            }
-        } else {
-            single
-        }
+        single
     } else {
         let nodes = arena.push_slice(nodes);
         arena.push(Node::Row {
@@ -3393,11 +3393,13 @@ fn relation_attrs(rel_category: symbol::RelCategory) -> OpAttrs {
     match rel_category {
         // Category A relations are stretchy by default; we explicitly
         // disable stretching for them.
-        RelCategory::A => OpAttrs::STRETCHY_FALSE,
-        RelCategory::Default => OpAttrs::empty(),
+        RelCategory::A => OpAttrs::STRETCHY_FALSE | OpAttrs::ROLE_INFIX,
+        RelCategory::Default => OpAttrs::ROLE_INFIX,
         // To get the right spacing on `DandForceDefault` relations, we have to
         // explicitly set the form to "infix".
-        RelCategory::DandForceDefault => OpAttrs::FORM_INFIX,
+        RelCategory::DandForceDefault => {
+            OpAttrs::FORM_INFIX | OpAttrs::ROLE_PREFIX | OpAttrs::ROLE_INFIX
+        }
     }
 }
 

--- a/crates/math-core/src/semantic.rs
+++ b/crates/math-core/src/semantic.rs
@@ -1,0 +1,683 @@
+//! Infers the invisible operators for math equations.
+//!
+//! Some of the rules in this file are lifted from MathGrammar in LaTeXML,
+//! but with significant simplification. In particular, they try to
+//! infer '\u{2062}' (invisible times), but we don't, because it's too much
+//! work to do correctly (and even LaTeXML gets it wrong in a few cases).
+//!
+//! Maybe that's a bad idea, and we should bite the bullet and use a
+//! semantic IR? We'd have to parse things like `a + 2 \bmod b`, recognizing
+//! `\bmod` as an infix operator, which isn't how we currently do it.
+//!
+//! The approach to parsing mostly comes from [matklad's][1] guide to PRATT parsing.
+//!
+//! [1]: https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
+use alloc::{vec, vec::Vec};
+
+use crate::parser::node_vec_to_node;
+use mathml_renderer::arena::Arena;
+use mathml_renderer::ast::Node;
+use mathml_renderer::attribute::{OpAttrs, RowAttrs};
+use mathml_renderer::symbol::FUNCTION_APPLICATION;
+
+pub struct EnrichParseResult<'arena> {
+    consumed: usize,
+    replaced_with: Option<Vec<&'arena Node<'arena>>>,
+}
+
+/// Convenience function to enrich and pass into a row.
+pub fn enrich_to_node<'arena>(
+    arena: &'arena Arena,
+    input: &'_ [&'arena Node<'arena>],
+    reset_spacing: bool,
+) -> &'arena Node<'arena> {
+    if reset_spacing
+        && let [single] = input
+        && let Node::Operator { op, attrs, .. } = **single
+    {
+        return arena.push(Node::Operator {
+            op,
+            attrs,
+            left: None,
+            right: None,
+            size: None,
+        });
+    }
+    node_vec_to_node(
+        arena,
+        &enrich(arena, input)
+    )
+}
+
+/// The base parsing function, which operates on a list of plain LaTeX AST
+/// nodes and turns out another list of AST nodes, but enriched with invisible
+/// operators.
+pub fn enrich<'arena>(
+    arena: &'arena Arena,
+    input: &'_ [&'arena Node<'arena>],
+) -> Vec<&'arena Node<'arena>> {
+    let mut lhs: EnrichParseResult<'arena> = enrich_formula(arena, input, 0);
+    while lhs.consumed < input.len() {
+        let rhs: EnrichParseResult = enrich_formula(arena, &input[lhs.consumed..], 0);
+        if lhs.replaced_with.is_some() || rhs.replaced_with.is_some() {
+            let mut lhs_replaced_with = lhs
+                .replaced_with
+                .take()
+                .unwrap_or_else(|| input[..lhs.consumed].to_vec());
+            lhs_replaced_with.extend_from_slice(
+                rhs.replaced_with
+                    .as_ref()
+                    .map(|r| &r[..])
+                    .unwrap_or(&input[lhs.consumed..][..rhs.consumed]),
+            );
+            lhs.replaced_with = Some(lhs_replaced_with);
+        }
+        lhs.consumed += rhs.consumed;
+    }
+
+    lhs.replaced_with.unwrap_or_else(|| input[..lhs.consumed].to_vec())
+}
+
+/// Enriches a single formula.
+///
+/// Returns early if it reaches an operator that binds tighter than `min_bp`.
+fn enrich_formula<'tmp, 'arena>(
+    arena: &'arena Arena,
+    input: &'tmp [&'arena Node<'arena>],
+    min_bp: u8,
+) -> EnrichParseResult<'arena> {
+    let mut lhs: EnrichParseResult<'arena> = {
+        let mut lhs = EnrichParseResult {
+            consumed: 0,
+            replaced_with: None,
+        };
+        // include spaces in the LHS without affecting precedence
+        while let Some(Node::Space(..)) = input.get(lhs.consumed) {
+            // lhs.replaced_with is definitely None at this point
+            lhs.consumed += 1;
+        }
+        if lhs.consumed >= input.len() {
+            return lhs;
+        }
+        let new_lhs = if let Some(lhs_bracketed) = enrich_bracketed(arena, &input[lhs.consumed..]) {
+            lhs_bracketed
+        } else if let Some(lhs_prefix) = enrich_prefix(arena, &input[lhs.consumed..]) {
+            lhs_prefix
+        } else if let Some(lhs_fn) = enrich_pseudo_operator(arena, &input[lhs.consumed..]) {
+            lhs_fn
+        } else if let Some((_, bp_r)) = infix_binding_power(input[lhs.consumed]) {
+            // LHS starts with an infix operator? Treat it like a prefix.
+            // \and y
+            // ^^^^^^
+            lhs.consumed += 1;
+            enrich_formula(arena, &input[lhs.consumed..], bp_r)
+        } else {
+            // LHS is an atom
+            EnrichParseResult {
+                consumed: 1,
+                replaced_with: None,
+            }
+        };
+        if lhs.replaced_with.is_some() || new_lhs.replaced_with.is_some() {
+            let lhs_replaced_with = lhs.replaced_with.get_or_insert_with(|| {
+                let mut lhs_replaced_with = Vec::new();
+                lhs_replaced_with.extend_from_slice(&input[..lhs.consumed]);
+                lhs_replaced_with
+            });
+            if let Some(mut new_lhs_replaced_with) = new_lhs.replaced_with {
+                lhs_replaced_with.append(&mut new_lhs_replaced_with);
+            } else {
+                lhs_replaced_with.extend_from_slice(&input[lhs.consumed..][..new_lhs.consumed]);
+            }
+        }
+        lhs.consumed += new_lhs.consumed;
+        lhs
+    };
+    while let Some([op, ..]) = input.get(lhs.consumed..) {
+        // include spaces in the RHS without affecting precedence
+        if let Node::Space(..) = op {
+            // lhs.replaced_with is definitely None at this point
+            lhs.consumed += 1;
+            if let Some(lhs_replaced_with) = lhs.replaced_with.as_mut() {
+                lhs_replaced_with.push(op);
+            }
+        } else if let Some((bp_l, ())) = postfix_binding_power(op) {
+            if bp_l < min_bp {
+                break;
+            }
+            if let Some(lhs_replaced_with) = lhs.replaced_with.as_mut() {
+                lhs_replaced_with.push(op);
+            }
+            lhs.consumed += 1;
+        } else {
+            let (bp_r, push_op) = if let Some((bp_l, bp_r)) = infix_binding_power(op) {
+                if bp_l < min_bp {
+                    break;
+                }
+                lhs.consumed += 1;
+                (bp_r, true)
+            } else {
+                let (bp_l, bp_r) = INFIX_BINDING_POWER_INVISIBLE_TIMES;
+                if bp_l < min_bp {
+                    break;
+                }
+                (bp_r, false)
+            };
+            let rhs: EnrichParseResult<'arena> =
+                enrich_formula(arena, &input[lhs.consumed..], bp_r);
+            if lhs.replaced_with.is_some() || rhs.replaced_with.is_some() {
+                let mut lhs_replaced_with = lhs
+                    .replaced_with
+                    .map(|mut lhs_replaced_with| {
+                        if push_op {
+                            lhs_replaced_with.push(op);
+                        }
+                        lhs_replaced_with
+                    })
+                    .unwrap_or_else(|| input[..lhs.consumed].to_vec());
+                if let Some(mut rhs_replaced_with) = rhs.replaced_with {
+                    lhs_replaced_with.append(&mut rhs_replaced_with);
+                } else {
+                    lhs_replaced_with.extend_from_slice(&input[lhs.consumed..][..rhs.consumed]);
+                }
+                lhs.replaced_with = Some(lhs_replaced_with);
+            }
+            lhs.consumed += rhs.consumed;
+        }
+    }
+    lhs
+}
+
+// LHS starts with a parenthesized list
+// (1 + 2) * 3
+// ^^^^^^^
+fn enrich_bracketed<'tmp, 'arena>(
+    arena: &'arena Arena,
+    input: &'tmp [&'arena Node<'arena>],
+) -> Option<EnrichParseResult<'arena>> {
+    if input.is_empty() {
+        return None;
+    }
+    let open = match operator(input.first()?)? {
+        Node::Operator { attrs, .. } if attrs.contains(OpAttrs::ROLE_OPEN) => input[0],
+        _ => return None,
+    };
+    let mut lhs: EnrichParseResult<'arena> = EnrichParseResult {
+        consumed: 0,
+        replaced_with: None,
+    };
+    lhs.consumed += 1;
+    // OpAttrs::ROLE_CLOSE has an infix binding power of 0, so that it can parse as an infix
+    // operator when it's unmatched.
+    //
+    // So, if we set min_bp to 1, enrich_formula will return control back to us if it finds one.
+    let rhs: EnrichParseResult<'arena> = enrich_formula(arena, &input[lhs.consumed..], 1);
+    let close = match operator(input.get(lhs.consumed + rhs.consumed)?)? {
+        Node::Operator { attrs, .. } if attrs.contains(OpAttrs::ROLE_CLOSE) => {
+            input[lhs.consumed + rhs.consumed]
+        }
+        _ => return None,
+    };
+    if let Some(rhs_replaced_with) = rhs.replaced_with {
+        // lhs.replaced_with is definitely None
+        lhs.replaced_with = Some(
+            [open][..]
+                .iter()
+                .chain(&rhs_replaced_with[..])
+                .chain(&[close])
+                .copied()
+                .collect(),
+        );
+    }
+    lhs.consumed += rhs.consumed + 1;
+    Some(lhs)
+}
+
+// LHS starts with a prefix operator
+// \not x \and y
+// ^^^^^^
+fn enrich_prefix<'tmp, 'arena>(
+    arena: &'arena Arena,
+    input: &'tmp [&'arena Node<'arena>],
+) -> Option<EnrichParseResult<'arena>> {
+    if input.is_empty() {
+        return None;
+    }
+    let mut lhs: EnrichParseResult<'arena> = EnrichParseResult {
+        consumed: 0,
+        replaced_with: None,
+    };
+    let ((), bp_r) = prefix_binding_power(input.get(lhs.consumed)?)?;
+    lhs.consumed += 1;
+    let rhs: EnrichParseResult<'arena> = enrich_formula(arena, &input[lhs.consumed..], bp_r);
+    if let Some(rhs_replaced_with) = rhs.replaced_with {
+        // lhs.replaced_with is definitely None
+        lhs.replaced_with = Some(
+            input[..lhs.consumed]
+                .iter()
+                .chain(&rhs_replaced_with)
+                .copied()
+                .collect(),
+        );
+    }
+    lhs.consumed += rhs.consumed;
+    Some(lhs)
+}
+
+fn enrich_pseudo_operator<'tmp, 'arena>(
+    arena: &'arena Arena,
+    input: &'tmp [&'arena Node<'arena>],
+) -> Option<EnrichParseResult<'arena>> {
+    if let (
+        identifier,
+        Node::PseudoOp {
+            name: _,
+            left: _,
+            right,
+            attrs,
+        },
+    ) = rewrite_pseudo_operator(input.first()?, arena)?
+    {
+        // LHS starts with a prefix pseudo-operator
+        // \sin x + y
+        // ^^^^^^
+        let mut lhs: EnrichParseResult<'arena> = EnrichParseResult {
+            consumed: 1,
+            replaced_with: None,
+        };
+        let rhs: EnrichParseResult<'arena> = enrich_formula(
+            arena,
+            &input[lhs.consumed..],
+            PREFIX_BINDING_POWER_PSEUDO_OPERATOR.1,
+        );
+        if rhs.consumed == 0 {
+            return None;
+        }
+        lhs.replaced_with = Some(vec![
+            arena.push(Node::Row {
+                nodes: arena.push_slice(&[
+                    identifier,
+                    arena.push(Node::Operator {
+                        op: FUNCTION_APPLICATION.as_op(),
+                        attrs: *attrs | OpAttrs::ROLE_INFIX & !OpAttrs::ROLE_PREFIX,
+                        // when the pseudo-op is being rewritten as a function, this U+2061
+                        // is to the right of the function name, so its right becomes our left
+                        left: *right,
+                        // the left spacing needs attached to something, but it's not clear what?
+                        // I'd want to attach it to the INVISIBLE_TIMES, but we don't have one.
+                        // Maybe the row?
+                        right: None,
+                        size: None,
+                    }),
+                    node_vec_to_node(
+                        arena,
+                        rhs.replaced_with
+                            .as_ref()
+                            .map(|r| &r[..])
+                            .unwrap_or_else(|| &input[lhs.consumed..][..rhs.consumed]),
+                    ),
+                ]),
+                attrs: RowAttrs::default(),
+            }),
+        ]);
+        lhs.consumed += rhs.consumed;
+        Some(lhs)
+    } else {
+        None
+    }
+}
+
+const INFIX_BINDING_POWER_CLOSE: (u8, u8) = (0, 0);
+const INFIX_BINDING_POWER: (u8, u8) = (1, 2);
+// We pretend that there's an INVISIBLE_TIMES operator for parsing precedence,
+// but we don't actually generate U+2062, because correctly generating it would
+// require a lot more parsing logic. Even LaTeXML gets it wrong sometimes!
+const INFIX_BINDING_POWER_INVISIBLE_TIMES: (u8, u8) = (3, 4);
+const INFIX_BINDING_POWER_FUNCTION_APPLICATION: (u8, u8) = (5, 6);
+const PREFIX_BINDING_POWER_PSEUDO_OPERATOR: ((), u8) = ((), 6);
+const PREFIX_BINDING_POWER: ((), u8) = ((), 8);
+const POSTFIX_BINDING_POWER: (u8, ()) = (9, ());
+
+fn prefix_binding_power(node: &Node<'_>) -> Option<((), u8)> {
+    Some(match operator(node)? {
+        Node::Operator { attrs, .. } if attrs.contains(OpAttrs::ROLE_PREFIX) => {
+            PREFIX_BINDING_POWER
+        }
+        Node::PseudoOp {
+            name: _,
+            left: _,
+            right: _,
+            attrs,
+        } if attrs.contains(OpAttrs::ROLE_PREFIX) => PREFIX_BINDING_POWER_PSEUDO_OPERATOR,
+        _ => return None,
+    })
+}
+
+fn postfix_binding_power(node: &Node<'_>) -> Option<(u8, ())> {
+    Some(match operator(node)? {
+        Node::Operator { attrs, .. } if attrs.contains(OpAttrs::ROLE_POSTFIX) => {
+            POSTFIX_BINDING_POWER
+        }
+        _ => return None,
+    })
+}
+
+fn infix_binding_power(node: &Node<'_>) -> Option<(u8, u8)> {
+    Some(match operator(node)? {
+        Node::Operator { op, attrs, .. } if attrs.contains(OpAttrs::ROLE_INFIX) => {
+            match op.as_superchar().base_char() {
+                '\u{2062}' => INFIX_BINDING_POWER_INVISIBLE_TIMES,
+                '\u{2061}' => INFIX_BINDING_POWER_FUNCTION_APPLICATION,
+                _ => INFIX_BINDING_POWER,
+            }
+        }
+        Node::Operator { attrs, .. } if attrs.contains(OpAttrs::ROLE_CLOSE) => {
+            INFIX_BINDING_POWER_CLOSE
+        }
+        _ => return None,
+    })
+}
+
+fn rewrite_pseudo_operator<'tmp, 'arena>(
+    node: &'tmp Node<'arena>,
+    arena: &'arena Arena,
+) -> Option<(&'arena Node<'arena>, &'tmp Node<'arena>)> {
+    let mut original = None;
+    fn do_rewrite<'tmp, 'arena>(
+        node: &'tmp Node<'arena>,
+        arena: &'arena Arena,
+        original: &mut Option<&'tmp Node<'arena>>,
+        recursion: usize,
+    ) -> Option<&'arena Node<'arena>> {
+        if recursion >= 1000 {
+            return None;
+        }
+        Some(arena.push(match node {
+            Node::Sub { target, symbol } => Node::Sub {
+                target: do_rewrite(target, arena, original, recursion + 1)?,
+                symbol,
+            },
+            Node::Sup { target, symbol } => Node::Sup {
+                target: do_rewrite(target, arena, original, recursion + 1)?,
+                symbol,
+            },
+            Node::SubSup { target, sub, sup } => Node::SubSup {
+                target: do_rewrite(target, arena, original, recursion + 1)?,
+                sub,
+                sup,
+            },
+            Node::Over { target, symbol } => Node::Over {
+                target: do_rewrite(target, arena, original, recursion + 1)?,
+                symbol,
+            },
+            Node::Under { target, symbol } => Node::Under {
+                target: do_rewrite(target, arena, original, recursion + 1)?,
+                symbol,
+            },
+            Node::UnderOver {
+                target,
+                over,
+                under,
+            } => Node::UnderOver {
+                target: do_rewrite(target, arena, original, recursion + 1)?,
+                over,
+                under,
+            },
+            Node::PseudoOp { name, .. } => {
+                *original = Some(node);
+                Node::IdentifierStr(name)
+            }
+            _ => return None,
+        }))
+    }
+    let rewritten = do_rewrite(node, arena, &mut original, 0)?;
+    Some((rewritten, original?))
+}
+
+fn operator<'tmp, 'arena>(mut node: &'tmp Node<'arena>) -> Option<&'tmp Node<'arena>> {
+    let mut recursion = 0;
+    while recursion < 1000 {
+        node = match node {
+            Node::Sub { target, .. }
+            | Node::Sup { target, .. }
+            | Node::SubSup { target, .. }
+            | Node::Under { target, .. }
+            | Node::Over { target, .. }
+            | Node::UnderOver { target, .. } => target,
+            _ => break,
+        };
+        recursion += 1;
+    }
+    if let Node::Operator { .. } = node {
+        Some(node)
+    } else {
+        None
+    }
+}
+
+#[test]
+fn enrich_test() {
+    const FN_OP: mathml_renderer::symbol::MathMLOperator = const { FUNCTION_APPLICATION.as_op() };
+    const ADD_OP: mathml_renderer::symbol::MathMLOperator =
+        const { mathml_renderer::symbol::PLUS_SIGN.as_op() };
+    use std::assert_matches;
+    let arena = Arena::default();
+    // Basic tests
+    assert_matches!(
+        enrich_to_node(&arena, &[&Node::Number("1")][..], false),
+        &Node::Number("1")
+    );
+    assert_matches!(
+        enrich_to_node(&arena, &[][..], false),
+        &Node::Row { nodes: &[], .. }
+    );
+    // Basic infix operator tests
+    assert_matches!(
+        enrich_to_node(
+            &arena,
+            &[
+                &Node::Number("1"),
+                &Node::Operator {
+                    op: ADD_OP,
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::Number("1"),
+            ][..],
+            false,
+        ),
+        &Node::Row {
+            nodes: [
+                Node::Number("1"),
+                Node::Operator { op: ADD_OP, .. },
+                Node::Number("1"),
+            ],
+            ..
+        }
+    );
+    assert_matches!(
+        enrich_to_node(
+            &arena,
+            &[
+                &Node::Number("1"),
+                &Node::Operator {
+                    op: ADD_OP,
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::Number("1"),
+                &Node::Operator {
+                    op: ADD_OP,
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::IdentifierStr("x"),
+            ][..],
+            false,
+        ),
+        &Node::Row {
+            nodes: [
+                Node::Number("1"),
+                Node::Operator { op: ADD_OP, .. },
+                Node::Number("1"),
+                Node::Operator { op: ADD_OP, .. },
+                Node::IdentifierStr("x"),
+            ],
+            ..
+        }
+    );
+    // Combining an infix op with \sin
+    assert_matches!(
+        enrich_to_node(
+            &arena,
+            &[
+                &Node::PseudoOp {
+                    attrs: OpAttrs::empty(),
+                    left: None,
+                    right: None,
+                    name: "sin"
+                },
+                &Node::Number("1"),
+                &Node::Operator {
+                    op: const { mathml_renderer::symbol::PLUS_SIGN.as_op() },
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::Number("1"),
+            ][..],
+            false,
+        ),
+        &Node::Row {
+            nodes: [
+                Node::Row {
+                    nodes: [
+                        Node::IdentifierStr("sin"),
+                        Node::Operator { op: FN_OP, .. },
+                        Node::Number("1"),
+                    ],
+                    ..
+                },
+                Node::Operator { op: ADD_OP, .. },
+                Node::Number("1")
+            ],
+            ..
+        }
+    );
+    // Invisible times combined with \sin
+    assert_matches!(
+        enrich_to_node(
+            &arena,
+            &[
+                &Node::PseudoOp {
+                    attrs: OpAttrs::empty(),
+                    left: None,
+                    right: None,
+                    name: "sin"
+                },
+                &Node::Number("1"),
+                &Node::IdentifierStr("x"),
+            ][..],
+            false,
+        ),
+        &Node::Row {
+            nodes: [
+                Node::Row {
+                    nodes: [
+                        Node::IdentifierStr("sin"),
+                        Node::Operator { op: FN_OP, .. },
+                        Node::Number("1"),
+                    ],
+                    ..
+                },
+                Node::IdentifierStr("x")
+            ],
+            ..
+        }
+    );
+    // Invisible times combined with infix operator
+    assert_matches!(
+        enrich_to_node(
+            &arena,
+            &[
+                &Node::Number("1"),
+                &Node::Operator {
+                    op: const { mathml_renderer::symbol::PLUS_SIGN.as_op() },
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::Number("1"),
+                &Node::IdentifierStr("x"),
+                &Node::Operator {
+                    op: const { mathml_renderer::symbol::PLUS_SIGN.as_op() },
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::Number("1"),
+            ][..],
+            false,
+        ),
+        &Node::Row {
+            nodes: [
+                Node::Number("1"),
+                Node::Operator { op: ADD_OP, .. },
+                Node::Number("1"),
+                Node::IdentifierStr("x"),
+                Node::Operator { op: ADD_OP, .. },
+                Node::Number("1"),
+            ],
+            ..
+        }
+    );
+    // Invisible times chain
+    assert_matches!(
+        enrich_to_node(
+            &arena,
+            &[
+                &Node::IdentifierStr("a"),
+                &Node::Operator {
+                    op: const { mathml_renderer::symbol::PLUS_SIGN.as_op() },
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::IdentifierStr("b"),
+                &Node::IdentifierStr("c"),
+                &Node::IdentifierStr("d"),
+                &Node::Operator {
+                    op: const { mathml_renderer::symbol::PLUS_SIGN.as_op() },
+                    attrs: OpAttrs::ROLE_INFIX,
+                    size: None,
+                    left: None,
+                    right: None,
+                },
+                &Node::IdentifierStr("e"),
+            ][..],
+            false,
+        ),
+        &Node::Row {
+            nodes: [
+                Node::IdentifierStr("a"),
+                Node::Operator { op: ADD_OP, .. },
+                Node::IdentifierStr("b"),
+                Node::IdentifierStr("c"),
+                Node::IdentifierStr("d"),
+                Node::Operator { op: ADD_OP, .. },
+                Node::IdentifierStr("e"),
+            ],
+            ..
+        }
+    );
+}

--- a/crates/math-core/src/snapshots/math_core__parser__tests__big_paren.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__big_paren.snap
@@ -5,7 +5,7 @@ expression: "\\big("
 [
   Operator(
     op: "(",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_INFIX"),
     size: Some(Scale1),
     left: None,
     right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__colon_fusion_in_subscript.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__colon_fusion_in_subscript.snap
@@ -7,7 +7,7 @@ expression: "x_:\\equiv, x_:="
     target: IdentifierChar("x", Default),
     symbol: Operator(
       op: ":",
-      attrs: OpAttrs(""),
+      attrs: OpAttrs("ROLE_INFIX"),
       size: None,
       left: None,
       right: None,
@@ -15,7 +15,7 @@ expression: "x_:\\equiv, x_:="
   ),
   Operator(
     op: "≡",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_INFIX"),
     size: None,
     left: None,
     right: Some(Zero),
@@ -31,7 +31,7 @@ expression: "x_:\\equiv, x_:="
     target: IdentifierChar("x", Default),
     symbol: Operator(
       op: ":",
-      attrs: OpAttrs(""),
+      attrs: OpAttrs("ROLE_INFIX"),
       size: None,
       left: None,
       right: None,
@@ -39,7 +39,7 @@ expression: "x_:\\equiv, x_:="
   ),
   Operator(
     op: "=",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_INFIX"),
     size: None,
     left: None,
     right: Some(Zero),

--- a/crates/math-core/src/snapshots/math_core__parser__tests__colon_fusion_stop.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__colon_fusion_stop.snap
@@ -5,7 +5,7 @@ expression: ":2=:="
 [
   Operator(
     op: ":",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_INFIX"),
     size: None,
     left: Some(Zero),
     right: Some(FiveMu),
@@ -13,21 +13,21 @@ expression: ":2=:="
   Number("2"),
   Operator(
     op: "=",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_INFIX"),
     size: None,
     left: None,
     right: Some(Zero),
   ),
   Operator(
     op: ":",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_INFIX"),
     size: None,
     left: Some(Zero),
     right: Some(Zero),
   ),
   Operator(
     op: "=",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_INFIX"),
     size: None,
     left: Some(Zero),
     right: Some(Zero),

--- a/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_end.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_end.snap
@@ -10,7 +10,7 @@ expression: "\\begin{matrix}\\sum\\displaystyle\\sum\\end{matrix}"
     content: [
       Operator(
         op: "∑",
-        attrs: OpAttrs(""),
+        attrs: OpAttrs("ROLE_PREFIX"),
         size: None,
         left: Some(Zero),
         right: None,
@@ -19,7 +19,7 @@ expression: "\\begin{matrix}\\sum\\displaystyle\\sum\\end{matrix}"
         nodes: [
           Operator(
             op: "∑",
-            attrs: OpAttrs(""),
+            attrs: OpAttrs("ROLE_PREFIX"),
             size: None,
             left: Some(Zero),
             right: Some(Zero),

--- a/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_right.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__displaystyle_ended_by_right.snap
@@ -16,7 +16,7 @@ expression: "\\left(\\displaystyle \\int\\right)\\int"
         nodes: [
           Operator(
             op: "∫",
-            attrs: OpAttrs(""),
+            attrs: OpAttrs("ROLE_PREFIX"),
             size: None,
             left: Some(Zero),
             right: Some(Zero),
@@ -44,7 +44,7 @@ expression: "\\left(\\displaystyle \\int\\right)\\int"
   ),
   Operator(
     op: "∫",
-    attrs: OpAttrs(""),
+    attrs: OpAttrs("ROLE_PREFIX"),
     size: None,
     left: None,
     right: Some(Zero),

--- a/crates/math-core/src/snapshots/math_core__parser__tests__int_bounds_relation.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__int_bounds_relation.snap
@@ -8,7 +8,7 @@ expression: "{\\int_0^\\infty = 4}"
       SubSup(
         target: Operator(
           op: "∫",
-          attrs: OpAttrs(""),
+          attrs: OpAttrs("ROLE_PREFIX"),
           size: None,
           left: Some(Zero),
           right: Some(Zero),
@@ -18,7 +18,7 @@ expression: "{\\int_0^\\infty = 4}"
       ),
       Operator(
         op: "=",
-        attrs: OpAttrs(""),
+        attrs: OpAttrs("ROLE_INFIX"),
         size: None,
         left: None,
         right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__int_relation.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__int_relation.snap
@@ -7,14 +7,14 @@ expression: "{\\int = 4}"
     nodes: [
       Operator(
         op: "∫",
-        attrs: OpAttrs(""),
+        attrs: OpAttrs("ROLE_PREFIX"),
         size: None,
         left: Some(Zero),
         right: Some(Zero),
       ),
       Operator(
         op: "=",
-        attrs: OpAttrs(""),
+        attrs: OpAttrs("ROLE_INFIX"),
         size: None,
         left: None,
         right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__integral_with_reversed_limits.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__integral_with_reversed_limits.snap
@@ -6,7 +6,7 @@ expression: "\\int\\limits^1_0 dx"
   UnderOver(
     target: Operator(
       op: "∫",
-      attrs: OpAttrs(""),
+      attrs: OpAttrs("ROLE_PREFIX"),
       size: None,
       left: Some(Zero),
       right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathit_func.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathit_func.snap
@@ -6,13 +6,24 @@ expression: "\\mathit{ab \\log cd}"
   Row(
     nodes: [
       IdentifierStr("𝑎𝑏"),
-      PseudoOp(
-        attrs: OpAttrs(""),
-        left: Some(ThreeMu),
-        right: Some(ThreeMu),
-        name: "log",
+      Row(
+        nodes: [
+          IdentifierStr("log"),
+          Operator(
+            op: "\u{2061}",
+            attrs: OpAttrs("ROLE_INFIX"),
+            size: None,
+            left: Some(ThreeMu),
+            right: None,
+          ),
+          IdentifierStr("𝑐𝑑"),
+        ],
+        attrs: RowAttrs(
+          color: None,
+          style: None,
+          math_shift_compact: false,
+        ),
       ),
-      IdentifierStr("𝑐𝑑"),
     ],
     attrs: RowAttrs(
       color: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathit_of_max.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathit_of_max.snap
@@ -6,13 +6,24 @@ expression: "\\mathit{ab \\max \\alpha\\beta}"
   Row(
     nodes: [
       IdentifierStr("𝑎𝑏"),
-      PseudoOp(
-        attrs: OpAttrs(""),
-        left: Some(ThreeMu),
-        right: Some(ThreeMu),
-        name: "max",
+      Row(
+        nodes: [
+          IdentifierStr("max"),
+          Operator(
+            op: "\u{2061}",
+            attrs: OpAttrs("ROLE_INFIX"),
+            size: None,
+            left: Some(ThreeMu),
+            right: None,
+          ),
+          IdentifierStr("𝛼𝛽"),
+        ],
+        attrs: RowAttrs(
+          color: None,
+          style: None,
+          math_shift_compact: false,
+        ),
       ),
-      IdentifierStr("𝛼𝛽"),
     ],
     attrs: RowAttrs(
       color: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__mathstrut.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__mathstrut.snap
@@ -7,7 +7,7 @@ expression: "\\mathstrut"
     node: Phantom(
       node: Operator(
         op: "(",
-        attrs: OpAttrs("STRETCHY_FALSE"),
+        attrs: OpAttrs("STRETCHY_FALSE | ROLE_OPEN"),
         size: None,
         left: None,
         right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__number_after_lim.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__number_after_lim.snap
@@ -7,7 +7,7 @@ expression: "\\sum\\limits_12"
     symbol: Number("1"),
     target: Operator(
       op: "∑",
-      attrs: OpAttrs("NO_MOVABLE_LIMITS"),
+      attrs: OpAttrs("NO_MOVABLE_LIMITS | ROLE_PREFIX"),
       size: None,
       left: Some(Zero),
       right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__pmod_subscript.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__pmod_subscript.snap
@@ -9,7 +9,7 @@ expression: "\\pmod{3}_4"
   )),
   Operator(
     op: "(",
-    attrs: OpAttrs("STRETCHY_FALSE"),
+    attrs: OpAttrs("STRETCHY_FALSE | ROLE_OPEN"),
     size: None,
     left: None,
     right: None,
@@ -23,7 +23,7 @@ expression: "\\pmod{3}_4"
   Sub(
     target: Operator(
       op: ")",
-      attrs: OpAttrs("STRETCHY_FALSE"),
+      attrs: OpAttrs("STRETCHY_FALSE | ROLE_CLOSE"),
       size: None,
       left: None,
       right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__sub_big_paren.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__sub_big_paren.snap
@@ -7,7 +7,7 @@ expression: "x_\\big("
     target: IdentifierChar("x", Default),
     symbol: Operator(
       op: "(",
-      attrs: OpAttrs(""),
+      attrs: OpAttrs("ROLE_INFIX"),
       size: Some(Scale1),
       left: None,
       right: None,

--- a/crates/math-core/src/snapshots/math_core__parser__tests__sum_relation.snap
+++ b/crates/math-core/src/snapshots/math_core__parser__tests__sum_relation.snap
@@ -7,14 +7,14 @@ expression: "{\\sum = 4}"
     nodes: [
       Operator(
         op: "∑",
-        attrs: OpAttrs(""),
+        attrs: OpAttrs("ROLE_PREFIX"),
         size: None,
         left: Some(Zero),
         right: Some(Zero),
       ),
       Operator(
         op: "=",
-        attrs: OpAttrs(""),
+        attrs: OpAttrs("ROLE_INFIX"),
         size: None,
         left: None,
         right: None,

--- a/crates/math-core/tests/snapshots/conversion_test__log_in_big.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__log_in_big.snap
@@ -4,10 +4,18 @@ expression: "\\bigl(\\log\\bigr) + \\big(\\log\\big)"
 ---
 <math>
     <mo minsize="1.2em" maxsize="1.2em">(</mo>
-    <mo lspace="0" rspace="0">log</mo>
-    <mo minsize="1.2em" maxsize="1.2em">)</mo>
-    <mo>+</mo>
-    <mo minsize="1.2em" maxsize="1.2em">(</mo>
-    <mo lspace="0.1667em" rspace="0.1667em">log</mo>
-    <mo minsize="1.2em" maxsize="1.2em">)</mo>
+    <mrow>
+        <mrow><mspace/><mi>log</mi></mrow>
+        <mo lspace="0">⁡</mo>
+        <mrow>
+            <mo minsize="1.2em" maxsize="1.2em">)</mo>
+            <mo>+</mo>
+            <mo minsize="1.2em" maxsize="1.2em">(</mo>
+            <mrow>
+                <mrow><mspace/><mi>log</mi></mrow>
+                <mo lspace="0.1667em">⁡</mo>
+                <mo minsize="1.2em" maxsize="1.2em">)</mo>
+            </mrow>
+        </mrow>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__mathit_of_max.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__mathit_of_max.snap
@@ -5,7 +5,10 @@ expression: "\\mathit{ab \\max \\alpha\\beta}"
 <math>
     <mrow>
         <mrow><mspace/><mi>𝑎𝑏</mi></mrow>
-        <mo lspace="0.1667em" rspace="0.1667em">max</mo>
-        <mrow><mspace/><mi>𝛼𝛽</mi></mrow>
+        <mrow>
+            <mrow><mspace/><mi>max</mi></mrow>
+            <mo lspace="0.1667em">⁡</mo>
+            <mrow><mspace/><mi>𝛼𝛽</mi></mrow>
+        </mrow>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__mathit_of_operatorname.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__mathit_of_operatorname.snap
@@ -5,7 +5,10 @@ expression: "\\mathit{a\\operatorname{bc}d}"
 <math>
     <mrow>
         <mi>𝑎</mi>
-        <mo lspace="0.1667em" rspace="0.1667em">bc</mo>
-        <mi>𝑑</mi>
+        <mrow>
+            <mrow><mspace/><mi>bc</mi></mrow>
+            <mo lspace="0.1667em">⁡</mo>
+            <mi>𝑑</mi>
+        </mrow>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__mathrm_with_sin2.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__mathrm_with_sin2.snap
@@ -4,7 +4,8 @@ expression: "\\mathrm{\\sin x}"
 ---
 <math>
     <mrow>
-        <mo lspace="0" rspace="0.1667em">sin</mo>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0.1667em">⁡</mo>
         <mrow><mspace/><mi mathvariant="normal">x</mi></mrow>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__max_with_limits.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__max_with_limits.snap
@@ -3,9 +3,12 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\max\\limits_x y"
 ---
 <math>
-    <munder>
-        <mo lspace="0" rspace="0.1667em">max</mo>
-        <mi>x</mi>
-    </munder>
-    <mi>y</mi>
+    <mrow>
+        <munder>
+            <mrow><mspace/><mi>max</mi></mrow>
+            <mi>x</mi>
+        </munder>
+        <mo lspace="0.1667em">⁡</mo>
+        <mi>y</mi>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__operator_name.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__operator_name.snap
@@ -3,6 +3,9 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\operatorname{sn} x"
 ---
 <math>
-    <mo lspace="0" rspace="0.1667em">sn</mo>
-    <mi>x</mi>
+    <mrow>
+        <mrow><mspace/><mi>sn</mi></mrow>
+        <mo lspace="0.1667em">⁡</mo>
+        <mi>x</mi>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__over.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__over.snap
@@ -5,20 +5,28 @@ expression: "{\\log x + a^n - \\sin(\\theta+\\eta) \\over x}"
 <math>
     <mfrac>
         <mrow>
-            <mo lspace="0" rspace="0.1667em">log</mo>
-            <mi>x</mi>
+            <mrow>
+                <mrow><mspace/><mi>log</mi></mrow>
+                <mo lspace="0.1667em">⁡</mo>
+                <mi>x</mi>
+            </mrow>
             <mo>+</mo>
             <msup>
                 <mi>a</mi>
                 <mi>n</mi>
             </msup>
             <mo>−</mo>
-            <mo lspace="0" rspace="0">sin</mo>
-            <mo stretchy="false">(</mo>
-            <mi>θ</mi>
-            <mo>+</mo>
-            <mi>η</mi>
-            <mo stretchy="false">)</mo>
+            <mrow>
+                <mrow><mspace/><mi>sin</mi></mrow>
+                <mo lspace="0">⁡</mo>
+                <mrow>
+                    <mo stretchy="false">(</mo>
+                    <mi>θ</mi>
+                    <mo>+</mo>
+                    <mi>η</mi>
+                    <mo stretchy="false">)</mo>
+                </mrow>
+            </mrow>
         </mrow>
         <mi>x</mi>
     </mfrac>

--- a/crates/math-core/tests/snapshots/conversion_test__sin_plus_cos.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sin_plus_cos.snap
@@ -3,7 +3,12 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\sin + \\cos"
 ---
 <math>
-    <mo lspace="0" rspace="0.1667em">sin</mo>
-    <mo lspace="0" rspace="0">+</mo>
-    <mo lspace="0.1667em" rspace="0">cos</mo>
+    <mrow>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0.1667em">⁡</mo>
+        <mrow>
+            <mo lspace="0" rspace="0">+</mo>
+            <mo lspace="0.1667em" rspace="0">cos</mo>
+        </mrow>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sine_at_group_start.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sine_at_group_start.snap
@@ -5,7 +5,8 @@ expression: "x{\\sin x}"
 <math>
     <mi>x</mi>
     <mrow>
-        <mo lspace="0" rspace="0.1667em">sin</mo>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0.1667em">⁡</mo>
         <mi>x</mi>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sine_function.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sine_function.snap
@@ -3,6 +3,9 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\sin x"
 ---
 <math>
-    <mo lspace="0" rspace="0.1667em">sin</mo>
-    <mi>x</mi>
+    <mrow>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0.1667em">⁡</mo>
+        <mi>x</mi>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sine_function_brackets.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sine_function_brackets.snap
@@ -3,8 +3,13 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\sin\\{x\\}"
 ---
 <math>
-    <mo lspace="0" rspace="0">sin</mo>
-    <mo stretchy="false">{</mo>
-    <mi>x</mi>
-    <mo stretchy="false">}</mo>
+    <mrow>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0">⁡</mo>
+        <mrow>
+            <mo stretchy="false">{</mo>
+            <mi>x</mi>
+            <mo stretchy="false">}</mo>
+        </mrow>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sine_function_parens.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sine_function_parens.snap
@@ -3,8 +3,13 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\sin(x)"
 ---
 <math>
-    <mo lspace="0" rspace="0">sin</mo>
-    <mo stretchy="false">(</mo>
-    <mi>x</mi>
-    <mo stretchy="false">)</mo>
+    <mrow>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0">⁡</mo>
+        <mrow>
+            <mo stretchy="false">(</mo>
+            <mi>x</mi>
+            <mo stretchy="false">)</mo>
+        </mrow>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sine_function_sqbrackets.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sine_function_sqbrackets.snap
@@ -3,8 +3,13 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\sin[x]"
 ---
 <math>
-    <mo lspace="0" rspace="0">sin</mo>
-    <mo stretchy="false">[</mo>
-    <mi>x</mi>
-    <mo stretchy="false">]</mo>
+    <mrow>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0">⁡</mo>
+        <mrow>
+            <mo stretchy="false">[</mo>
+            <mi>x</mi>
+            <mo stretchy="false">]</mo>
+        </mrow>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sine_function_stretch_parens.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sine_function_stretch_parens.snap
@@ -3,10 +3,13 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\sin\\left(x\\right)"
 ---
 <math>
-    <mo lspace="0" rspace="0">sin</mo>
     <mrow>
-        <mo>(</mo>
-        <mi>x</mi>
-        <mo>)</mo>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0">⁡</mo>
+        <mrow>
+            <mo>(</mo>
+            <mi>x</mi>
+            <mo>)</mo>
+        </mrow>
     </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sine_sine.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sine_sine.snap
@@ -3,7 +3,13 @@ source: crates/math-core/tests/conversion_test.rs
 expression: "\\sin\\sin x"
 ---
 <math>
-    <mo lspace="0" rspace="0.1667em">sin</mo>
-    <mo lspace="0" rspace="0.1667em">sin</mo>
-    <mi>x</mi>
+    <mrow>
+        <mrow><mspace/><mi>sin</mi></mrow>
+        <mo lspace="0.1667em">⁡</mo>
+        <mrow>
+            <mrow><mspace/><mi>sin</mi></mrow>
+            <mo lspace="0.1667em">⁡</mo>
+            <mi>x</mi>
+        </mrow>
+    </mrow>
 </math>

--- a/crates/math-core/tests/snapshots/conversion_test__sum_log.snap
+++ b/crates/math-core/tests/snapshots/conversion_test__sum_log.snap
@@ -4,6 +4,9 @@ expression: "\\sum\\log n"
 ---
 <math>
     <mo lspace="0">∑</mo>
-    <mo lspace="0" rspace="0.1667em">log</mo>
-    <mi>n</mi>
+    <mrow>
+        <mrow><mspace/><mi>log</mi></mrow>
+        <mo lspace="0.1667em">⁡</mo>
+        <mi>n</mi>
+    </mrow>
 </math>

--- a/crates/mathml-renderer/src/attribute.rs
+++ b/crates/mathml-renderer/src/attribute.rs
@@ -22,6 +22,12 @@ bitflags! {
         const FORM_POSTFIX = 1 << 6;
         const SYMMETRIC_TRUE = 1 << 7;
         const LARGEOP_TRUE = 1 << 8;
+        const ROLE_OPEN = 1 << 9;
+        const ROLE_CLOSE = 1 << 10;
+        const ROLE_PREFIX = 1 << 11;
+        const ROLE_INFIX = 1 << 12;
+        const ROLE_POSTFIX = 1 << 13;
+        const ROLE_RELOP = 1 << 14;
     }
 }
 

--- a/crates/mathml-renderer/src/symbol.rs
+++ b/crates/mathml-renderer/src/symbol.rs
@@ -495,6 +495,8 @@ pub const QUADRUPLE_PRIME: OrdLike = OrdLike::new('⁗', OrdCategory::E);
 
 pub const MEDIUM_MATHEMATICAL_SPACE: char = '\u{205F}';
 
+pub const FUNCTION_APPLICATION: OrdLike = OrdLike::new('\u{2061}', OrdCategory::K);
+pub const INVISIBLE_TIMES: OrdLike = OrdLike::new('\u{2062}', OrdCategory::K);
 pub const INVISIBLE_SEPARATOR: OrdLike = OrdLike::new('\u{2063}', OrdCategory::K);
 
 //

--- a/playground/wiki_test.html
+++ b/playground/wiki_test.html
@@ -298,19 +298,25 @@
             <td><code>\exp_a b = a^b, \exp b = e^b, 10^m</code></td>
             <td>
                 <math display="block">
-                    <msub>
-                        <mo lspace="0" rspace="0.1667em">exp</mo>
-                        <mi>a</mi>
-                    </msub>
-                    <mi>b</mi>
+                    <mrow>
+                        <msub>
+                            <mrow><mspace/><mi>exp</mi></mrow>
+                            <mi>a</mi>
+                        </msub>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>b</mi>
+                    </mrow>
                     <mo>=</mo>
                     <msup>
                         <mi>a</mi>
                         <mi>b</mi>
                     </msup>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">exp</mo>
-                    <mi>b</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>exp</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>b</mi>
+                    </mrow>
                     <mo>=</mo>
                     <msup>
                         <mi>e</mi>
@@ -329,20 +335,32 @@
             <td><code>\ln c, \lg d = \log e, \log_{10} f</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">ln</mo>
-                    <mi>c</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>ln</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>c</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">lg</mo>
-                    <mi>d</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>lg</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>d</mi>
+                    </mrow>
                     <mo>=</mo>
-                    <mo lspace="0" rspace="0.1667em">log</mo>
-                    <mi>e</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>log</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>e</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <msub>
-                        <mo lspace="0" rspace="0.1667em">log</mo>
-                        <mn>10</mn>
-                    </msub>
-                    <mi>f</mi>
+                    <mrow>
+                        <msub>
+                            <mrow><mspace/><mi>log</mi></mrow>
+                            <mn>10</mn>
+                        </msub>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>f</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -351,23 +369,41 @@
             <td><code>\sin a, \cos b, \tan c, \cot d, \sec e, \csc f</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">sin</mo>
-                    <mi>a</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>sin</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>a</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">cos</mo>
-                    <mi>b</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>cos</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>b</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">tan</mo>
-                    <mi>c</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>tan</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>c</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">cot</mo>
-                    <mi>d</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>cot</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>d</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">sec</mo>
-                    <mi>e</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>sec</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>e</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">csc</mo>
-                    <mi>f</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>csc</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>f</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -376,14 +412,23 @@
             <td><code>\arcsin h, \arccos i, \arctan j</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">arcsin</mo>
-                    <mi>h</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>arcsin</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>h</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">arccos</mo>
-                    <mi>i</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>arccos</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>i</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">arctan</mo>
-                    <mi>j</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>arctan</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>j</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -392,17 +437,29 @@
             <td><code>\sinh k, \cosh l, \tanh m, \coth n</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">sinh</mo>
-                    <mi>k</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>sinh</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>k</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">cosh</mo>
-                    <mi>l</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>cosh</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>l</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">tanh</mo>
-                    <mi>m</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>tanh</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>m</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">coth</mo>
-                    <mi>n</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>coth</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>n</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -411,17 +468,29 @@
             <td><code>\operatorname{sh}k, \operatorname{ch}l, \operatorname{th}m, \operatorname{coth}n</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">sh</mo>
-                    <mi>k</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>sh</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>k</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">ch</mo>
-                    <mi>l</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>ch</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>l</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">th</mo>
-                    <mi>m</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>th</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>m</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">coth</mo>
-                    <mi>n</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>coth</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>n</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -430,8 +499,11 @@
             <td><code>\sgn r, \left\vert s \right\vert</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">sgn</mo>
-                    <mi>r</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>sgn</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>r</mi>
+                    </mrow>
                     <mo>,</mo>
                     <mrow>
                         <mo>|</mo>
@@ -446,19 +518,29 @@
             <td><code>\min(x,y), \max(x,y)</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0">min</mo>
-                    <mo stretchy="false">(</mo>
-                    <mi>x</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>min</mi></mrow>
+                        <mo lspace="0">⁡</mo>
+                        <mrow>
+                            <mo stretchy="false">(</mo>
+                            <mi>x</mi>
+                            <mo>,</mo>
+                            <mi>y</mi>
+                            <mo stretchy="false">)</mo>
+                        </mrow>
+                    </mrow>
                     <mo>,</mo>
-                    <mi>y</mi>
-                    <mo stretchy="false">)</mo>
-                    <mo>,</mo>
-                    <mo lspace="0" rspace="0">max</mo>
-                    <mo stretchy="false">(</mo>
-                    <mi>x</mi>
-                    <mo>,</mo>
-                    <mi>y</mi>
-                    <mo stretchy="false">)</mo>
+                    <mrow>
+                        <mrow><mspace/><mi>max</mi></mrow>
+                        <mo lspace="0">⁡</mo>
+                        <mrow>
+                            <mo stretchy="false">(</mo>
+                            <mi>x</mi>
+                            <mo>,</mo>
+                            <mi>y</mi>
+                            <mo stretchy="false">)</mo>
+                        </mrow>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -468,17 +550,29 @@
             <td><code>\min x, \max y, \inf s, \sup t</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">min</mo>
-                    <mi>x</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>min</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>x</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">max</mo>
-                    <mi>y</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>max</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>y</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">inf</mo>
-                    <mi>s</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>inf</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>s</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">sup</mo>
-                    <mi>t</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>sup</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>t</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -487,14 +581,23 @@
             <td><code>\lim u, \liminf v, \limsup w</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">lim</mo>
-                    <mi>u</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>lim</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>u</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">lim inf</mo>
-                    <mi>v</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>lim inf</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>v</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">lim sup</mo>
-                    <mi>w</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>lim sup</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>w</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -503,17 +606,29 @@
             <td><code>\dim p, \deg q, \det m, \ker\phi</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">dim</mo>
-                    <mi>p</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>dim</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>p</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">deg</mo>
-                    <mi>q</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>deg</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>q</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">det</mo>
-                    <mi>m</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>det</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>m</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">ker</mo>
-                    <mi>ϕ</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>ker</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>ϕ</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -523,18 +638,27 @@
             <td><code>\Pr j, \hom l, \lVert z \rVert, \arg z</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0.1667em">Pr</mo>
-                    <mi>j</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>Pr</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>j</mi>
+                    </mrow>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">hom</mo>
-                    <mi>l</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>hom</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>l</mi>
+                    </mrow>
                     <mo>,</mo>
                     <mo stretchy="false" form="prefix">‖</mo>
                     <mi>z</mi>
                     <mo stretchy="false" form="postfix">‖</mo>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0.1667em">arg</mo>
-                    <mi>z</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>arg</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>z</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -756,19 +880,29 @@
             <td><code>\gcd(m, n), \operatorname{lcm}(m, n)</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0">gcd</mo>
-                    <mo stretchy="false">(</mo>
-                    <mi>m</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>gcd</mi></mrow>
+                        <mo lspace="0">⁡</mo>
+                        <mrow>
+                            <mo stretchy="false">(</mo>
+                            <mi>m</mi>
+                            <mo>,</mo>
+                            <mi>n</mi>
+                            <mo stretchy="false">)</mo>
+                        </mrow>
+                    </mrow>
                     <mo>,</mo>
-                    <mi>n</mi>
-                    <mo stretchy="false">)</mo>
-                    <mo>,</mo>
-                    <mo lspace="0" rspace="0">lcm</mo>
-                    <mo stretchy="false">(</mo>
-                    <mi>m</mi>
-                    <mo>,</mo>
-                    <mi>n</mi>
-                    <mo stretchy="false">)</mo>
+                    <mrow>
+                        <mrow><mspace/><mi>lcm</mi></mrow>
+                        <mo lspace="0">⁡</mo>
+                        <mrow>
+                            <mo stretchy="false">(</mo>
+                            <mi>m</mi>
+                            <mo>,</mo>
+                            <mi>n</mi>
+                            <mo stretchy="false">)</mo>
+                        </mrow>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -2653,18 +2787,21 @@
             <td><code>\lim_{n \to \infty}x_n</code></td>
             <td>
                 <math display="block">
-                    <munder>
-                        <mo movablelimits="true" lspace="0" rspace="0.1667em">lim</mo>
-                        <mrow>
+                    <mrow>
+                        <munder>
+                            <mrow><mspace/><mi>lim</mi></mrow>
+                            <mrow>
+                                <mi>n</mi>
+                                <mo stretchy="false" lspace="0" rspace="0">→</mo>
+                                <mi>∞</mi>
+                            </mrow>
+                        </munder>
+                        <mo movablelimits="true" lspace="0.1667em">⁡</mo>
+                        <msub>
+                            <mi>x</mi>
                             <mi>n</mi>
-                            <mo stretchy="false" lspace="0" rspace="0">→</mo>
-                            <mi>∞</mi>
-                        </mrow>
-                    </munder>
-                    <msub>
-                        <mi>x</mi>
-                        <mi>n</mi>
-                    </msub>
+                        </msub>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -5090,24 +5227,27 @@
             <td><code>\operatorname*{median}_{j\,\ne\,i} X_{i,j}</code></td>
             <td>
                 <math display="block">
-                    <munder>
-                        <mo movablelimits="true" lspace="0" rspace="0.1667em">median</mo>
-                        <mrow>
-                            <mi>j</mi>
-                            <mspace width="0.16666667em"/>
-                            <mo lspace="0" rspace="0">≠</mo>
-                            <mspace width="0.16666667em"/>
-                            <mi>i</mi>
-                        </mrow>
-                    </munder>
-                    <msub>
-                        <mi>X</mi>
-                        <mrow>
-                            <mi>i</mi>
-                            <mo rspace="0">,</mo>
-                            <mi>j</mi>
-                        </mrow>
-                    </msub>
+                    <mrow>
+                        <munder>
+                            <mrow><mspace/><mi>median</mi></mrow>
+                            <mrow>
+                                <mi>j</mi>
+                                <mspace width="0.16666667em"/>
+                                <mo lspace="0" rspace="0">≠</mo>
+                                <mspace width="0.16666667em"/>
+                                <mi>i</mi>
+                            </mrow>
+                        </munder>
+                        <mo movablelimits="true" lspace="0.1667em">⁡</mo>
+                        <msub>
+                            <mi>X</mi>
+                            <mrow>
+                                <mi>i</mi>
+                                <mo rspace="0">,</mo>
+                                <mi>j</mi>
+                            </mrow>
+                        </msub>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -5320,8 +5460,11 @@
                         <mrow>
                             <mi>t</mi>
                             <mo stretchy="false">(</mo>
-                            <mo lspace="0" rspace="0.1667em">ln</mo>
-                            <mi>t</mi>
+                            <mrow>
+                                <mrow><mspace/><mi>ln</mi></mrow>
+                                <mo lspace="0.1667em">⁡</mo>
+                                <mi>t</mi>
+                            </mrow>
                             <msup>
                                 <mo stretchy="false">)</mo>
                                 <mn>2</mn>
@@ -5340,7 +5483,8 @@
                                     <mn>1</mn>
                                 </mrow>
                                 <mrow>
-                                    <mo lspace="0" rspace="0.1667em">ln</mo>
+                                    <mrow><mspace/><mi>ln</mi></mrow>
+                                    <mo lspace="0.1667em">⁡</mo>
                                     <mi>t</mi>
                                 </mrow>
                             </mfrac>
@@ -5359,13 +5503,18 @@
             <td><code>\det(\mathsf{A}-\lambda\mathsf{I}) = 0</code></td>
             <td>
                 <math display="block">
-                    <mo lspace="0" rspace="0">det</mo>
-                    <mo stretchy="false">(</mo>
-                    <mi>𝖠</mi>
-                    <mo>−</mo>
-                    <mi>λ</mi>
-                    <mi>𝖨</mi>
-                    <mo stretchy="false">)</mo>
+                    <mrow>
+                        <mrow><mspace/><mi>det</mi></mrow>
+                        <mo lspace="0">⁡</mo>
+                        <mrow>
+                            <mo stretchy="false">(</mo>
+                            <mi>𝖠</mi>
+                            <mo>−</mo>
+                            <mi>λ</mi>
+                            <mi>𝖨</mi>
+                            <mo stretchy="false">)</mo>
+                        </mrow>
+                    </mrow>
                     <mo>=</mo>
                     <mn>0</mn>
                 </math>
@@ -5521,19 +5670,29 @@
                         <mi>n</mi>
                     </msup>
                     <mo>,</mo>
-                    <mo lspace="0" rspace="0">arg</mo>
-                    <mo stretchy="false">(</mo>
-                    <msup>
-                        <mi>z</mi>
-                        <mi>n</mi>
-                    </msup>
-                    <mo stretchy="false">)</mo>
+                    <mrow>
+                        <mrow><mspace/><mi>arg</mi></mrow>
+                        <mo lspace="0">⁡</mo>
+                        <mrow>
+                            <mo stretchy="false">(</mo>
+                            <msup>
+                                <mi>z</mi>
+                                <mi>n</mi>
+                            </msup>
+                            <mo stretchy="false">)</mo>
+                        </mrow>
+                    </mrow>
                     <mo>=</mo>
                     <mi>n</mi>
-                    <mo lspace="0.1667em" rspace="0">arg</mo>
-                    <mo stretchy="false">(</mo>
-                    <mi>z</mi>
-                    <mo stretchy="false">)</mo>
+                    <mrow>
+                        <mrow><mspace/><mi>arg</mi></mrow>
+                        <mo lspace="0">⁡</mo>
+                        <mrow>
+                            <mo stretchy="false">(</mo>
+                            <mi>z</mi>
+                            <mo stretchy="false">)</mo>
+                        </mrow>
+                    </mrow>
                 </math>
             </td>
         </tr>
@@ -5542,18 +5701,21 @@
             <td><code>\lim_{z\to z_0} f(z)=f(z_0)</code></td>
             <td>
                 <math display="block">
-                    <munder>
-                        <mo movablelimits="true" lspace="0" rspace="0.1667em">lim</mo>
-                        <mrow>
-                            <mi>z</mi>
-                            <mo stretchy="false" lspace="0" rspace="0">→</mo>
-                            <msub>
+                    <mrow>
+                        <munder>
+                            <mrow><mspace/><mi>lim</mi></mrow>
+                            <mrow>
                                 <mi>z</mi>
-                                <mn>0</mn>
-                            </msub>
-                        </mrow>
-                    </munder>
-                    <mi>f</mi>
+                                <mo stretchy="false" lspace="0" rspace="0">→</mo>
+                                <msub>
+                                    <mi>z</mi>
+                                    <mn>0</mn>
+                                </msub>
+                            </mrow>
+                        </munder>
+                        <mo movablelimits="true" lspace="0.1667em">⁡</mo>
+                        <mi>f</mi>
+                    </mrow>
                     <mo stretchy="false">(</mo>
                     <mi>z</mi>
                     <mo stretchy="false">)</mo>
@@ -5863,8 +6025,11 @@
                     <mo>=</mo>
                     <mi>d</mi>
                     <mi>D</mi>
-                    <mo lspace="0.1667em" rspace="0.1667em">sin</mo>
-                    <mi>α</mi>
+                    <mrow>
+                        <mrow><mspace/><mi>sin</mi></mrow>
+                        <mo lspace="0.1667em">⁡</mo>
+                        <mi>α</mi>
+                    </mrow>
                 </math>
             </td>
         </tr>


### PR DESCRIPTION
This tries to copy the behavior, roughly, of LaTeXML's "math parser." To avoid ambiguity, I call this phase "semantic enrichment."

Doing enrichment completely requires you to distinguish operators from identifiers, so that you can distinguish Invisible Times from other operators, and we don't always have that information. However, I have tried to do it well enough to parse trig functions. Not sure if half-doing it is a good idea or not?

CC https://github.com/tmke8/math-core/issues/668